### PR TITLE
refactor/ruleset-structure

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,7 +155,7 @@ enum class Key : uint8_t {
 Inside the constructor, the function is generated and bound to each ruleset that needs it:
 ```cpp
 auto const baseListFunc = generateBaseListFunction(baseKeys);
-bind<alignCenterName>(Interaction::Rules::StaticRuleset::Type::Local, &Camera::alignCenter, alignCenterDesc, baseListFunc);
+bind<alignCenterName>(&Camera::alignCenter, baseListFunc, Interaction::Rules::StaticRuleset::Type::Local, alignCenterDesc);
 // ... bind other rulesets
 ```
 On invocation, both slf and otr have the same list of variables. Use `baseVal(<enum>)` to access the variables in the ruleset function:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,7 +155,7 @@ enum class Key : uint8_t {
 Inside the constructor, the function is generated and bound to each ruleset that needs it:
 ```cpp
 auto const baseListFunc = generateBaseListFunction(baseKeys);
-bind<alignCenterName>(RulesetType::Local, &Camera::alignCenter, alignCenterDesc, baseListFunc);
+bind<alignCenterName>(Interaction::Rules::Ruleset::Type::Local, &Camera::alignCenter, alignCenterDesc, baseListFunc);
 // ... bind other rulesets
 ```
 On invocation, both slf and otr have the same list of variables. Use `baseVal(<enum>)` to access the variables in the ruleset function:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,7 +155,7 @@ enum class Key : uint8_t {
 Inside the constructor, the function is generated and bound to each ruleset that needs it:
 ```cpp
 auto const baseListFunc = generateBaseListFunction(baseKeys);
-bind<alignCenterName>(Interaction::Rules::Ruleset::Type::Local, &Camera::alignCenter, alignCenterDesc, baseListFunc);
+bind<alignCenterName>(Interaction::Rules::StaticRuleset::Type::Local, &Camera::alignCenter, alignCenterDesc, baseListFunc);
 // ... bind other rulesets
 ```
 On invocation, both slf and otr have the same list of variables. Use `baseVal(<enum>)` to access the variables in the ruleset function:

--- a/include/Nebulite/Interaction/Logic/Expression.hpp
+++ b/include/Nebulite/Interaction/Logic/Expression.hpp
@@ -355,6 +355,8 @@ private:
      */
     void reset();
 
+    std::string buildStringRepresentation(std::string_view expression, VariableNameGenerator& varNameGen);
+
     //------------------------------------------
     // Parsing and compiling
 

--- a/include/Nebulite/Interaction/Logic/Expression.hpp
+++ b/include/Nebulite/Interaction/Logic/Expression.hpp
@@ -21,6 +21,7 @@
 // Nebulite
 #include "Nebulite/Data/Document/JSON.hpp"
 #include "Nebulite/Interaction/Context.hpp"
+#include "Nebulite/Interaction/Logic/ExpressionComponent.hpp"
 #include "Nebulite/Interaction/Logic/LinkedNumericValue.hpp"
 
 //------------------------------------------
@@ -33,7 +34,6 @@ class ScopedKeyView;
 } // namespace Nebulite::Data
 
 namespace Nebulite::Interaction::Logic {
-class ExpressionComponent;
 class LinkedNumericValue;
 class VariableNameGenerator;
 } // namespace Nebulite::Interaction::Logic
@@ -325,7 +325,7 @@ private:
     /**
      * @brief Holds all parsed components from the expression.
      */
-    std::vector<std::shared_ptr<ExpressionComponent>> components;
+    std::vector<std::unique_ptr<ExpressionComponent>> components;
 
     /**
      * @brief Holds the full expression as a string.
@@ -355,8 +355,6 @@ private:
      */
     void reset();
 
-    std::string buildStringRepresentation(std::string_view expression, VariableNameGenerator& varNameGen);
-
     //------------------------------------------
     // Parsing and compiling
 
@@ -370,7 +368,7 @@ private:
      * @brief Compiles a component, if its of type Expression
      * @param component The component to potentially compile
      */
-    void compileIfExpression(std::shared_ptr<ExpressionComponent> const& component) const;
+    void compileIfExpression(std::unique_ptr<ExpressionComponent> const& component) const;
 
     /**
      * @brief Parses the given expression into a series of components.
@@ -400,7 +398,7 @@ private:
     /**
      * @brief Prints a compilation error message to cerr, includes tips for fixing the error.
      */
-    void printCompileError(std::shared_ptr<ExpressionComponent> const& component, int error) const ;
+    void printCompileError(std::unique_ptr<ExpressionComponent> const& component, int error) const ;
 
     /**
      * @brief Registers a variable with the given name and key in the context of the component.

--- a/include/Nebulite/Interaction/Rules/Construction/RulesetCompiler.hpp
+++ b/include/Nebulite/Interaction/Rules/Construction/RulesetCompiler.hpp
@@ -5,7 +5,6 @@
 // Includes
 
 // Standard library
-#include <cstddef>
 #include <memory>
 #include <optional>
 #include <string>
@@ -15,7 +14,6 @@
 
 // Nebulite
 #include "Nebulite/Data/Document/ScopedKeyView.hpp"
-#include "Nebulite/Interaction/Logic/Assignment.hpp"
 
 //------------------------------------------
 // Forward declarations
@@ -76,14 +74,6 @@ private:
      * @param Ruleset The Ruleset object to populate with function calls.
      */
     static void getFunctionCalls(Data::JsonScope const& entryDoc, JsonRuleset& Ruleset);
-
-    /**
-     * @brief Extract a single expression from a JSON entry document
-     * @param entry The JSON entry document to extract the expression from.
-     * @param index The index of the expression in the entry document.
-     * @return The extracted expression as a Logic::Assignment object, or std::nullopt if extraction failed.
-     */
-    static std::optional<Logic::Assignment> getAssignment(Data::JsonScope const& entry, std::size_t index);
 
     /**
      * @brief Extracts all expressions from a JSON entry document.

--- a/include/Nebulite/Interaction/Rules/Construction/RulesetCompiler.hpp
+++ b/include/Nebulite/Interaction/Rules/Construction/RulesetCompiler.hpp
@@ -14,9 +14,8 @@
 #include <vector>
 
 // Nebulite
-#include "Nebulite/Data/Document/ScopedKey.hpp"
+#include "Nebulite/Data/Document/ScopedKeyView.hpp"
 #include "Nebulite/Interaction/Logic/Assignment.hpp"
-#include "Nebulite/Interaction/Rules/Ruleset.hpp"
 
 //------------------------------------------
 // Forward declarations
@@ -25,16 +24,31 @@ namespace Nebulite::Data {
 class JsonScope;
 } // namespace Nebulite::Data
 
+namespace Nebulite::Interaction::Execution {
+class Domain;
+} // namespace Nebulite::Interaction::Execution
+
+namespace Nebulite::Interaction::Rules {
+class Ruleset;
+class JsonRuleset;
+class StaticRuleset;
+} // namespace Nebulite::Interaction::Rules
+
 //------------------------------------------
 namespace Nebulite::Interaction::Rules::Construction {
 /**
  * @class RulesetCompiler
  * @brief Responsible for parsing compatible JSON documents into `Ruleset` structs.
+ * @todo The current ruleset integration should be flexible enough to integrate this into the Ruleset classes on construction?
  */
 class RulesetCompiler {
 public:
     // A wrapper for all ruleset types, or none
-    using AnyRuleset = std::variant<std::monostate, std::shared_ptr<StaticRuleset>, std::shared_ptr<JsonRuleset>>;
+    using AnyRuleset = std::variant<
+        std::monostate,
+        std::shared_ptr<StaticRuleset>,
+        std::shared_ptr<JsonRuleset>
+    >;
 
     using RulesetVector = std::vector<std::shared_ptr<Ruleset>>;
 

--- a/include/Nebulite/Interaction/Rules/Ruleset.hpp
+++ b/include/Nebulite/Interaction/Rules/Ruleset.hpp
@@ -7,6 +7,8 @@
 // Standard library
 #include <algorithm>
 #include <cstddef>
+#include <cstdint>
+#include <functional>
 #include <memory>
 #include <string>
 #include <vector>
@@ -14,7 +16,6 @@
 // Nebulite
 #include "Nebulite/Interaction/Logic/Assignment.hpp"
 #include "Nebulite/Interaction/Logic/Expression.hpp"
-#include "Nebulite/Interaction/Rules/StaticRulesetMap.hpp"
 
 //------------------------------------------
 // Forward declarations
@@ -31,6 +32,10 @@ class Domain;
 namespace Nebulite::Interaction::Rules {
 struct Listener;
 } // namespace Nebulite::Interaction::Rules
+
+namespace Nebulite::Module::Base {
+class RulesetModule;
+} // namespace Nebulite::Module::Base
 
 //------------------------------------------
 namespace Nebulite::Interaction::Rules {
@@ -55,6 +60,18 @@ public:
     Ruleset& operator=(Ruleset const&) = delete;
     Ruleset(Ruleset&&) = delete;
     Ruleset& operator=(Ruleset&&) = delete;
+
+    //------------------------------------------
+    // Types, used for metadata
+
+    enum class Type : std::uint8_t {
+        Local,
+        Global,
+        invalid
+    };
+
+    using StaticRulesetFunction = void (*)(void*, Context const&, double**, double**);
+    using BaseListFunction = std::function<double**(Execution::Domain const&)>;
 
     //------------------------------------------
     // Friend classes
@@ -205,6 +222,7 @@ public:
     StaticRuleset(StaticRuleset&&) = delete;
     StaticRuleset& operator=(StaticRuleset&&) = delete;
 
+
     //------------------------------------------
     // Friend classes
     friend class Construction::RulesetCompiler;
@@ -248,6 +266,7 @@ public:
 
 private:
     StaticRulesetFunction staticFunction = nullptr;
+    void* instance = nullptr;
 };
 
 /**

--- a/include/Nebulite/Interaction/Rules/Ruleset.hpp
+++ b/include/Nebulite/Interaction/Rules/Ruleset.hpp
@@ -69,8 +69,8 @@ public:
     // Methods: Getters
 
     /**
-     * @brief Gets the id of the ruleset.
-     * @return The id of the ruleset, as const reference.
+     * @brief Gets the id of the ruleset owner.
+     * @return The id of the owner, as const reference.
      */
     [[nodiscard]] std::size_t getId() const ;
 
@@ -80,12 +80,6 @@ public:
     * @return The hashed id of the ruleset, as const reference.
     */
     [[nodiscard]] std::size_t getIdHashed() const ;
-
-    /**
-     * @brief Gets the index of the ruleset in the owning Domain's list of entries.
-     * @return The index of the ruleset, as const reference.
-     */
-    [[nodiscard]] std::size_t getIndex() const { return index; }
 
     /**
      * @brief Returns the topic of the ruleset.
@@ -103,7 +97,7 @@ public:
      * @brief Checks whether the ruleset is global.
      * @return True if the ruleset is global, false otherwise.
      */
-    [[nodiscard]] bool isGlobal() const { return _isGlobal; }
+    [[nodiscard]] bool isGlobal() const { return !topic.empty(); }
 
     //------------------------------------------
     // Methods: Workflow
@@ -148,12 +142,6 @@ protected:
     std::size_t index = 0;
 
     /**
-     * @brief Indicates whether the ruleset is global or local.
-     * @details if true, the Ruleset is global and can be broadcasted to other objects: Same as a nonempty topic
-     */
-    bool _isGlobal = true;
-
-    /**
      * @brief Pointer to the Domain that owns this ruleset; the `self` domain.
      */
     Execution::Domain& self;
@@ -165,13 +153,9 @@ protected:
 
     /**
      * @brief The topic of the ruleset, used for routing and filtering in the broadcast-listen-model of the Invoke class.
-     * @details e.g. `gravity`, `hitbox`, `collision`. `all` is the default value. Any Domain listening should be subscribed to this topic.
-     *          However, we are allowed to remove the topic listen `all` from any object, though it is not recommended.
-     *          As an example, say we wish to implement a console feature to quickly remove any object.
-     *          We can do so by sending an `ambassador` object that finds all other object at location (x,y) and deletes them.
-     *          This object would broadcast its invoke to `all`. Removing any objects subscription to `all` makes this impossible.
-     *
-     *          Due to the large checks needed for `all`, it should only be used when absolutely necessary.
+     * @details Not the same as the name of the ruleset, which is not stored.
+     *          If the ruleset is local, the topic is empty.
+     * @todo Use topicId instead? + modulo-based rulesetmap?
      */
     std::string topic = "all";
 };
@@ -255,7 +239,7 @@ public:
 
 private:
     Function staticFunction = nullptr;
-    BaseListFunction baseListFunction;
+    BaseListFunction baseListFunction = nullptr;
 
     /**
      * @brief Ordered list of variables for this ruleset to use as self

--- a/include/Nebulite/Interaction/Rules/Ruleset.hpp
+++ b/include/Nebulite/Interaction/Rules/Ruleset.hpp
@@ -209,7 +209,7 @@ public:
         invalid
     };
 
-    using Function = void (*)(void*, Context const&, double**, double**);
+    using Function = std::function<void(const Context&, double** slf, double** otr)>;
     using BaseListFunction = std::function<double**(Execution::Domain const&)>;
 
     //------------------------------------------
@@ -254,10 +254,7 @@ public:
     void applyDomain(Execution::Domain& global) override ;
 
 private:
-    void* instance = nullptr;
-
     Function staticFunction = nullptr;
-
     BaseListFunction baseListFunction;
 
     /**

--- a/include/Nebulite/Interaction/Rules/Ruleset.hpp
+++ b/include/Nebulite/Interaction/Rules/Ruleset.hpp
@@ -62,18 +62,6 @@ public:
     Ruleset& operator=(Ruleset&&) = delete;
 
     //------------------------------------------
-    // Types, used for metadata
-
-    enum class Type : std::uint8_t {
-        Local,
-        Global,
-        invalid
-    };
-
-    using StaticRulesetFunction = void (*)(void*, Context const&, double**, double**);
-    using BaseListFunction = std::function<double**(Execution::Domain const&)>;
-
-    //------------------------------------------
     // Friend classes
     friend class Construction::RulesetCompiler;
 
@@ -186,16 +174,6 @@ protected:
      *          Due to the large checks needed for `all`, it should only be used when absolutely necessary.
      */
     std::string topic = "all";
-
-    /**
-     * @brief BaseList generator function
-     */
-    BaseListFunction baseListFunction;
-
-    /**
-     * @brief Ordered list of variables for this ruleset to use as self
-     */
-    double** slf = nullptr;
 };
 
 /**
@@ -222,6 +200,17 @@ public:
     StaticRuleset(StaticRuleset&&) = delete;
     StaticRuleset& operator=(StaticRuleset&&) = delete;
 
+    //------------------------------------------
+    // Types
+
+    enum class Type : std::uint8_t {
+        Local,
+        Global,
+        invalid
+    };
+
+    using Function = void (*)(void*, Context const&, double**, double**);
+    using BaseListFunction = std::function<double**(Execution::Domain const&)>;
 
     //------------------------------------------
     // Friend classes
@@ -265,8 +254,16 @@ public:
     void applyDomain(Execution::Domain& global) override ;
 
 private:
-    StaticRulesetFunction staticFunction = nullptr;
     void* instance = nullptr;
+
+    Function staticFunction = nullptr;
+
+    BaseListFunction baseListFunction;
+
+    /**
+     * @brief Ordered list of variables for this ruleset to use as self
+     */
+    double** slf = nullptr;
 };
 
 /**

--- a/include/Nebulite/Interaction/Rules/StaticRulesetMap.hpp
+++ b/include/Nebulite/Interaction/Rules/StaticRulesetMap.hpp
@@ -5,8 +5,6 @@
 // Includes
 
 // Standard library
-#include <cstdint>
-#include <functional>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -16,6 +14,7 @@
 
 // Nebulite
 #include "Nebulite/Interaction/Context.hpp"
+#include "Nebulite/Interaction/Rules/Ruleset.hpp"
 
 //------------------------------------------
 // Forward declarations
@@ -33,26 +32,17 @@ class Domain;
 namespace Nebulite::Interaction::Rules {
 
 //------------------------------------------
-// Defining what a ruleset function looks like
-
-using StaticRulesetFunction = std::function<void(const Context&, double** slf, double** otr)>;
-using BaseListFunction = std::function<double**(Execution::Domain const&)>;
-
-//------------------------------------------
 // Defining a Ruleset Map where static rulesets can be looked up by name
 
 class StaticRulesetMap {
 public:
     struct StaticRulesetWithMetadata {
-        enum class Type : std::uint8_t {
-            Local,
-            Global,
-            invalid
-        } type = Type::invalid;
+        Ruleset::Type type = Ruleset::Type::invalid;
         std::string_view topic;
         std::string_view description;
-        StaticRulesetFunction function = nullptr;
-        BaseListFunction baseListFunc = nullptr;
+        void* instance;
+        Ruleset::StaticRulesetFunction function = nullptr;
+        Ruleset::BaseListFunction baseListFunc = nullptr;
     };
 
     StaticRulesetMap();
@@ -72,7 +62,7 @@ public:
 
     // Owned version of metadata for sharing info
     struct StaticRulesetMetadata {
-        StaticRulesetWithMetadata::Type type;
+        Ruleset::Type type;
         std::string topic;
         std::string description;
     };
@@ -102,9 +92,10 @@ public:
 private:
     absl::flat_hash_map<std::string, StaticRulesetWithMetadata> container;
     StaticRulesetWithMetadata invalidEntry{
-        .type=StaticRulesetWithMetadata::Type::invalid,
+        .type=Ruleset::Type::invalid,
         .topic="",
         .description="",
+        .instance=nullptr,
         .function=nullptr
     };
 
@@ -112,7 +103,7 @@ private:
     void help(Context const& context, double** slf, double** otr) const ;
     static std::string_view constexpr helpName = "::help";
     static std::string_view constexpr helpDesc = "Lists all available static rulesets with their descriptions.";
-    BaseListFunction const helpBaseListFunc = [](const Execution::Domain&) -> double** {return nullptr;};
+    Ruleset::BaseListFunction const helpBaseListFunc = [](const Execution::Domain&) -> double** {return nullptr;};
 };
 } // namespace Nebulite::Interaction::Rules
 #endif // NEBULITE_INTERACTION_RULES_STATICRULESETMAP_HPP

--- a/include/Nebulite/Interaction/Rules/StaticRulesetMap.hpp
+++ b/include/Nebulite/Interaction/Rules/StaticRulesetMap.hpp
@@ -37,12 +37,12 @@ namespace Nebulite::Interaction::Rules {
 class StaticRulesetMap {
 public:
     struct StaticRulesetWithMetadata {
-        Ruleset::Type type = Ruleset::Type::invalid;
+        StaticRuleset::Type type = StaticRuleset::Type::invalid;
         std::string_view topic;
         std::string_view description;
         void* instance;
-        Ruleset::StaticRulesetFunction function = nullptr;
-        Ruleset::BaseListFunction baseListFunc = nullptr;
+        StaticRuleset::Function function = nullptr;
+        StaticRuleset::BaseListFunction baseListFunc = nullptr;
     };
 
     StaticRulesetMap();
@@ -62,7 +62,7 @@ public:
 
     // Owned version of metadata for sharing info
     struct StaticRulesetMetadata {
-        Ruleset::Type type;
+        StaticRuleset::Type type;
         std::string topic;
         std::string description;
     };
@@ -92,7 +92,7 @@ public:
 private:
     absl::flat_hash_map<std::string, StaticRulesetWithMetadata> container;
     StaticRulesetWithMetadata invalidEntry{
-        .type=Ruleset::Type::invalid,
+        .type=StaticRuleset::Type::invalid,
         .topic="",
         .description="",
         .instance=nullptr,
@@ -103,7 +103,7 @@ private:
     void help(Context const& context, double** slf, double** otr) const ;
     static std::string_view constexpr helpName = "::help";
     static std::string_view constexpr helpDesc = "Lists all available static rulesets with their descriptions.";
-    Ruleset::BaseListFunction const helpBaseListFunc = [](const Execution::Domain&) -> double** {return nullptr;};
+    StaticRuleset::BaseListFunction const helpBaseListFunc = [](const Execution::Domain&) -> double** {return nullptr;};
 };
 } // namespace Nebulite::Interaction::Rules
 #endif // NEBULITE_INTERACTION_RULES_STATICRULESETMAP_HPP

--- a/include/Nebulite/Interaction/Rules/StaticRulesetMap.hpp
+++ b/include/Nebulite/Interaction/Rules/StaticRulesetMap.hpp
@@ -40,7 +40,6 @@ public:
         StaticRuleset::Type type = StaticRuleset::Type::invalid;
         std::string_view topic;
         std::string_view description;
-        void* instance;
         StaticRuleset::Function function = nullptr;
         StaticRuleset::BaseListFunction baseListFunc = nullptr;
     };
@@ -95,7 +94,6 @@ private:
         .type=StaticRuleset::Type::invalid,
         .topic="",
         .description="",
-        .instance=nullptr,
         .function=nullptr
     };
 

--- a/include/Nebulite/Module/Base/RulesetModule.hpp
+++ b/include/Nebulite/Module/Base/RulesetModule.hpp
@@ -69,33 +69,32 @@ protected:
      * @brief helper function to add a static ruleset to this module
      * @tparam topic The topic/name of the ruleset
      * @tparam DerivedRulesetModule The derived RulesetModule type
-     * @tparam Func The function implementing the ruleset
      * @param type The type of the ruleset (Local/Global)
+     * @param func The function implementing the ruleset
      * @param description A brief description of the ruleset's purpose and its used variables
      * @param baseListFunc A function that returns the ordered cache list of base values required by this ruleset, given a context.
      * @todo Add an argument param std::span<std::string> const& args, so that we can have rulesets with arguments such as
      *       ::Controls::PT1 path.to.pt1.object
      *       topic must reduce to the first arg, and we must add the args to the static ruleset object
      */
-    template<std::string_view const& topic, typename DerivedRulesetModule, auto Func>
+    template<std::string_view const& topic, typename DerivedRulesetModule>
     void bind(
-        Interaction::Rules::StaticRuleset::Type type,
-        std::string_view description,
-        Interaction::Rules::StaticRuleset::BaseListFunction const& baseListFunc
+        void (DerivedRulesetModule::*func)(Interaction::Context const&, double**, double**) const,
+        Interaction::Rules::StaticRuleset::BaseListFunction const& baseListFunc,
+        Interaction::Rules::StaticRuleset::Type const& type,
+        std::string_view description
     ){
-        assert(Func != nullptr);
+        assert(func != nullptr);
         static_assert(isValidTopic(topic), "RulesetModule::bind(): The topic name is not valid. It must start with '::' and contain no spaces.");
-        static_assert(std::is_base_of_v<RulesetModule, DerivedRulesetModule>, "RulesetModule::bind(): T must derive from RulesetModule");
-        static_assert(std::is_same_v<decltype(DerivedRulesetModule::moduleName), const std::string_view>, "RulesetModule::bind(): DerivedRulesetModule must have a static member 'moduleName' of type std::string_view");
         static_assert(topic.starts_with(DerivedRulesetModule::moduleName), "RulesetModule::bind(): The topic name must start with the module's name as prefix.");
+        static_assert(std::is_base_of_v<RulesetModule, DerivedRulesetModule>, "RulesetModule::bind(): T must derive from RulesetModule");
+        static_assert(std::is_same_v<decltype(DerivedRulesetModule::moduleName), std::string_view const>, "RulesetModule::bind(): DerivedRulesetModule must have a static member 'moduleName' of type std::string_view");
         moduleRulesets.push_back({
             type,
             topic,
             description,
-            this,
-            [](void* instance, Interaction::Context const& ctx, double** slf, double** otr) {
-                auto* self = static_cast<DerivedRulesetModule*>(instance);
-                (self->*Func)(ctx, slf, otr);
+            [this, func](Interaction::Context const& ctx, double** slf, double** otr) { (
+                static_cast<DerivedRulesetModule const*>(this)->*func)(ctx, slf, otr);
             },
             baseListFunc
         });

--- a/include/Nebulite/Module/Base/RulesetModule.hpp
+++ b/include/Nebulite/Module/Base/RulesetModule.hpp
@@ -82,7 +82,7 @@ protected:
         void (DerivedRulesetModule::*func)(Interaction::Context const&, double**, double**) const,
         Interaction::Rules::StaticRuleset::BaseListFunction const& baseListFunc,
         Interaction::Rules::StaticRuleset::Type const& type,
-        std::string_view description
+        std::string_view const description
     ){
         assert(func != nullptr);
         static_assert(isValidTopic(topic), "RulesetModule::bind(): The topic name is not valid. It must start with '::' and contain no spaces.");
@@ -93,8 +93,8 @@ protected:
             type,
             topic,
             description,
-            [this, func](Interaction::Context const& ctx, double** slf, double** otr) { (
-                static_cast<DerivedRulesetModule const*>(this)->*func)(ctx, slf, otr);
+            [this, func](Interaction::Context const& ctx, double** slf, double** otr) {
+                (static_cast<DerivedRulesetModule const*>(this)->*func)(ctx, slf, otr);
             },
             baseListFunc
         });

--- a/include/Nebulite/Module/Base/RulesetModule.hpp
+++ b/include/Nebulite/Module/Base/RulesetModule.hpp
@@ -13,6 +13,7 @@
 
 // Nebulite
 #include "Nebulite/Data/Document/ScopedKeyView.hpp"
+#include "Nebulite/Interaction/Rules/Ruleset.hpp"
 #include "Nebulite/Interaction/Rules/StaticRulesetMap.hpp"
 #include "Nebulite/ScopeAccessor.hpp"
 
@@ -33,8 +34,6 @@ namespace Nebulite::Module::Base {
  */
 class RulesetModule {
 public:
-    using RulesetType = Interaction::Rules::StaticRulesetMap::StaticRulesetWithMetadata::Type;
-
     explicit RulesetModule(std::string_view moduleName);
 
     /**
@@ -70,22 +69,21 @@ protected:
      * @brief helper function to add a static ruleset to this module
      * @tparam topic The topic/name of the ruleset
      * @tparam DerivedRulesetModule The derived RulesetModule type
+     * @tparam Func The function implementing the ruleset
      * @param type The type of the ruleset (Local/Global)
-     * @param func The function implementing the ruleset
      * @param description A brief description of the ruleset's purpose and its used variables
      * @param baseListFunc A function that returns the ordered cache list of base values required by this ruleset, given a context.
      * @todo Add an argument param std::span<std::string> const& args, so that we can have rulesets with arguments such as
      *       ::Controls::PT1 path.to.pt1.object
      *       topic must reduce to the first arg, and we must add the args to the static ruleset object
      */
-    template<std::string_view const& topic, typename DerivedRulesetModule>
+    template<std::string_view const& topic, typename DerivedRulesetModule, auto Func>
     void bind(
-        RulesetType const& type,
-        void (DerivedRulesetModule::*func)(Interaction::Context const&, double**, double**) const,
+        Interaction::Rules::Ruleset::Type type,
         std::string_view description,
-        Interaction::Rules::BaseListFunction const& baseListFunc
+        Interaction::Rules::Ruleset::BaseListFunction const& baseListFunc
     ){
-        assert(func != nullptr);
+        assert(Func != nullptr);
         static_assert(isValidTopic(topic), "RulesetModule::bind(): The topic name is not valid. It must start with '::' and contain no spaces.");
         static_assert(std::is_base_of_v<RulesetModule, DerivedRulesetModule>, "RulesetModule::bind(): T must derive from RulesetModule");
         static_assert(std::is_same_v<decltype(DerivedRulesetModule::moduleName), const std::string_view>, "RulesetModule::bind(): DerivedRulesetModule must have a static member 'moduleName' of type std::string_view");
@@ -94,8 +92,10 @@ protected:
             type,
             topic,
             description,
-            [this, func](Interaction::Context const& ctx, double** slf, double** otr) { (
-                static_cast<DerivedRulesetModule const*>(this)->*func)(ctx, slf, otr);
+            this,
+            [](void* instance, Interaction::Context const& ctx, double** slf, double** otr) {
+                auto* self = static_cast<DerivedRulesetModule*>(instance);
+                (self->*Func)(ctx, slf, otr);
             },
             baseListFunc
         });
@@ -123,7 +123,7 @@ protected:
      * @param baseKeys The key list to retrieve
      * @return The BaseList-ensurer function.
      */
-    [[nodiscard]] Interaction::Rules::BaseListFunction generateBaseListFunction(std::vector<Data::ScopedKeyView> const& baseKeys) const ;
+    [[nodiscard]] Interaction::Rules::Ruleset::BaseListFunction generateBaseListFunction(std::vector<Data::ScopedKeyView> const& baseKeys) const ;
 
     /**
      * @brief Checks if the global context is the actual GlobalSpace, and throws an exception if not.

--- a/include/Nebulite/Module/Base/RulesetModule.hpp
+++ b/include/Nebulite/Module/Base/RulesetModule.hpp
@@ -79,9 +79,9 @@ protected:
      */
     template<std::string_view const& topic, typename DerivedRulesetModule, auto Func>
     void bind(
-        Interaction::Rules::Ruleset::Type type,
+        Interaction::Rules::StaticRuleset::Type type,
         std::string_view description,
-        Interaction::Rules::Ruleset::BaseListFunction const& baseListFunc
+        Interaction::Rules::StaticRuleset::BaseListFunction const& baseListFunc
     ){
         assert(Func != nullptr);
         static_assert(isValidTopic(topic), "RulesetModule::bind(): The topic name is not valid. It must start with '::' and contain no spaces.");
@@ -123,7 +123,7 @@ protected:
      * @param baseKeys The key list to retrieve
      * @return The BaseList-ensurer function.
      */
-    [[nodiscard]] Interaction::Rules::Ruleset::BaseListFunction generateBaseListFunction(std::vector<Data::ScopedKeyView> const& baseKeys) const ;
+    [[nodiscard]] Interaction::Rules::StaticRuleset::BaseListFunction generateBaseListFunction(std::vector<Data::ScopedKeyView> const& baseKeys) const ;
 
     /**
      * @brief Checks if the global context is the actual GlobalSpace, and throws an exception if not.

--- a/include/Nebulite/Module/Ruleset/Debug.hpp
+++ b/include/Nebulite/Module/Ruleset/Debug.hpp
@@ -10,7 +10,8 @@
 #include <vector>
 
 // Nebulite
-#include "Nebulite/Data/Document/ScopedKey.hpp"
+#include "Nebulite/Data/Document/ScopedKeyView.hpp"
+#include "Nebulite/Interaction/Rules/Ruleset.hpp"
 #include "Nebulite/Module/Base/RulesetModule.hpp"
 
 //------------------------------------------
@@ -41,11 +42,11 @@ public:
         auto const baseListFunc = generateBaseListFunction(baseKeys);
 
         // Local
-        bind<messageName>(RulesetType::Local, &Debug::message, messageDesc, baseListFunc);
-        bind<errorName>(RulesetType::Local, &Debug::error, errorDesc, baseListFunc);
+        bind<messageName, Debug, &Debug::message>(Interaction::Rules::Ruleset::Type::Local, messageDesc, baseListFunc);
+        bind<errorName, Debug, &Debug::error>(Interaction::Rules::Ruleset::Type::Local, errorDesc, baseListFunc);
 
         // Global
-        bind<whoInteractsName>(RulesetType::Global, &Debug::whoInteracts, whoInteractsDesc, baseListFunc);
+        bind<whoInteractsName, Debug, &Debug::whoInteracts>(Interaction::Rules::Ruleset::Type::Global, whoInteractsDesc, baseListFunc);
     }
 
     static std::string_view constexpr moduleName = "::debug";

--- a/include/Nebulite/Module/Ruleset/Debug.hpp
+++ b/include/Nebulite/Module/Ruleset/Debug.hpp
@@ -42,11 +42,11 @@ public:
         auto const baseListFunc = generateBaseListFunction(baseKeys);
 
         // Local
-        bind<messageName, Debug, &Debug::message>(Interaction::Rules::StaticRuleset::Type::Local, messageDesc, baseListFunc);
-        bind<errorName, Debug, &Debug::error>(Interaction::Rules::StaticRuleset::Type::Local, errorDesc, baseListFunc);
+        bind<messageName>(&Debug::message, baseListFunc, Interaction::Rules::StaticRuleset::Type::Local, messageDesc);
+        bind<errorName>(&Debug::error, baseListFunc, Interaction::Rules::StaticRuleset::Type::Local, errorDesc);
 
         // Global
-        bind<whoInteractsName, Debug, &Debug::whoInteracts>(Interaction::Rules::StaticRuleset::Type::Global, whoInteractsDesc, baseListFunc);
+        bind<whoInteractsName>(&Debug::whoInteracts, baseListFunc, Interaction::Rules::StaticRuleset::Type::Global, whoInteractsDesc);
     }
 
     static std::string_view constexpr moduleName = "::debug";

--- a/include/Nebulite/Module/Ruleset/Debug.hpp
+++ b/include/Nebulite/Module/Ruleset/Debug.hpp
@@ -42,11 +42,11 @@ public:
         auto const baseListFunc = generateBaseListFunction(baseKeys);
 
         // Local
-        bind<messageName, Debug, &Debug::message>(Interaction::Rules::Ruleset::Type::Local, messageDesc, baseListFunc);
-        bind<errorName, Debug, &Debug::error>(Interaction::Rules::Ruleset::Type::Local, errorDesc, baseListFunc);
+        bind<messageName, Debug, &Debug::message>(Interaction::Rules::StaticRuleset::Type::Local, messageDesc, baseListFunc);
+        bind<errorName, Debug, &Debug::error>(Interaction::Rules::StaticRuleset::Type::Local, errorDesc, baseListFunc);
 
         // Global
-        bind<whoInteractsName, Debug, &Debug::whoInteracts>(Interaction::Rules::Ruleset::Type::Global, whoInteractsDesc, baseListFunc);
+        bind<whoInteractsName, Debug, &Debug::whoInteracts>(Interaction::Rules::StaticRuleset::Type::Global, whoInteractsDesc, baseListFunc);
     }
 
     static std::string_view constexpr moduleName = "::debug";

--- a/src/Interaction/AttributeCommand.cpp
+++ b/src/Interaction/AttributeCommand.cpp
@@ -15,6 +15,7 @@
 #include "Nebulite/Interaction/AttributeCommand.hpp"
 #include "Nebulite/Interaction/Execution/Domain.hpp"
 #include "Nebulite/Interaction/Rules/Construction/RulesetCompiler.hpp"
+#include "Nebulite/Interaction/Rules/Ruleset.hpp"
 #include "Nebulite/Utility/IO/Capture.hpp"
 #include "Nebulite/Utility/StringHandler.hpp"
 

--- a/src/Interaction/Logic/Expression.cpp
+++ b/src/Interaction/Logic/Expression.cpp
@@ -4,6 +4,7 @@
 // Standard library
 #include <algorithm>
 #include <cassert>
+#include <cmath>
 #include <cstddef>
 #include <cstdint> // NOLINT
 #include <iterator>
@@ -34,7 +35,6 @@
 #include "Nebulite/Utility/Coordination/RecursionAllocator.hpp"
 #include "Nebulite/Utility/Ranges.hpp"
 #include "Nebulite/Utility/StringHandler.hpp"
-
 
 //------------------------------------------
 namespace Nebulite::Interaction::Logic {
@@ -122,8 +122,7 @@ std::vector<std::string_view> getTokens(std::string_view const expr) {
             // Cannot be used, as splitOnSameDepth expects the first character to be the opening parenthesis
             auto const start = token.substr(0, token.find('('));
             auto const tokenWithoutStart = token.substr(start.length()); // Remove the leading '$' + formatter
-            auto subTokens = Utility::StringHandler::splitOnSameDepthOf(tokenWithoutStart, Utility::StringHandler::Delimiter::parentheses);
-            if (!subTokens.empty()) {
+            if (auto subTokens = Utility::StringHandler::splitOnSameDepthOf(tokenWithoutStart, Utility::StringHandler::Delimiter::parentheses); !subTokens.empty()) {
                 // Add the removed part
                 auto first = std::string_view(
                     start.data(),
@@ -246,6 +245,10 @@ int64_t Expression::evalAsInt(ContextScope const& context) const {
 
 bool Expression::evalAsBool(ContextScope const& context) const {
     double const result = evalAsDouble(context);
+    if (std::isnan(result)) {
+        // We consider NaN as false
+        return false;
+    }
     return !Math::isZero(result);
 }
 

--- a/src/Interaction/Logic/Expression.cpp
+++ b/src/Interaction/Logic/Expression.cpp
@@ -522,11 +522,9 @@ void Expression::parseIntoComponents() {
             // Current token is Text
             // Perhaps mixed with variables...
             for (auto const& subToken : Utility::StringHandler::splitOnSameDepthOf(token, Utility::StringHandler::Delimiter::brace)) {
-                // Token is type variable
                 if (isTypeVariable(subToken)) {
                     parseTokenTypeVariable(subToken);
                 }
-                // Token is type text
                 else {
                     parseTokenTypeText(subToken);
                 }
@@ -542,28 +540,22 @@ void Expression::parseIntoComponents() {
 }
 
 void Expression::parseTokenTypeEval(std::string_view const token, std::vector<LateRegistration>& lateRegistrations, VariableNameGenerator& varNameGen) {
-    // $[leading zero][alignment][.][precision]<type:f,i>
-    // - bool leading zero   : on/off
-    // - int alignment       : <0 means no formatting
-    // - int precision       : <0 means no formatting
-    // - CastType::none is then used to determine if we can simply use the double return from tinyexpr
+    // Extract formatter and expression
+    std::size_t const exprStart = token.find('('); // Opening parenthesis of the expression
+    auto const formatter = token.substr(1, exprStart - 1); // Remove leading $
+    auto const expression = token.substr(exprStart);
 
-    // 1.) find next '(' and split into formatter and token
-    // Examples:
-    // input        formatter       expression
-    // $(1+1)       ""              "(1+1)"
-    // $f(1.23)     "f"             "(1.23)"
-    // $i(42)       "i"             "(42)"
-    // $4.2f(2/3)   "4.2f"          "(2/3)"
+    // Write basic component data
     auto const currentComponent = std::make_shared<ExpressionComponent>();
-
-    std::size_t const pos = token.find('(');
-    auto const formatter = token.substr(1, pos - 1); // Remove leading $
-    auto const expression = token.substr(pos);
     currentComponent->formatter = Formatter::readFormatter(formatter);
+    currentComponent->type = ExpressionComponent::Type::eval;
+    currentComponent->contextType = ContextDeriver::TargetType::none; // None, since this is an eval expression
+    currentComponent->key = ""; // No key for eval expressions
 
     // Register internal variables
     // And build equivalent expression using new variable names
+    // New string length is hard to estimate; every shortened variable is  ~1 character in size compared to the arbitrary length of the original variable name.
+    currentComponent->stringRepresentation.reserve(expression.length() / 4);
     for (auto const& subToken : Utility::StringHandler::splitOnSameDepthOf(expression, Utility::StringHandler::Delimiter::brace)) {
         if (subToken.starts_with('{')) {
             auto const te_name = varNameGen.getUniqueName(subToken);
@@ -575,11 +567,6 @@ void Expression::parseTokenTypeEval(std::string_view const token, std::vector<La
             currentComponent->stringRepresentation += subToken;
         }
     }
-
-    // Write component data
-    currentComponent->type = ExpressionComponent::Type::eval;
-    currentComponent->contextType = ContextDeriver::TargetType::none; // None, since this is an eval expression
-    currentComponent->key = ""; // No key for eval expressions
 
     // Add to components
     components.push_back(currentComponent);

--- a/src/Interaction/Logic/Expression.cpp
+++ b/src/Interaction/Logic/Expression.cpp
@@ -516,21 +516,19 @@ void Expression::parseIntoComponents() {
     VariableNameGenerator variableNameGenerator;
     std::vector<LateRegistration> lateRegistrations;
     for (auto const& token : getTokens(fullExpression)) {
-        if (!token.empty()) {
-            if (token.starts_with('$')) {
-                parseTokenTypeEval(token, lateRegistrations, variableNameGenerator);
-            } else {
-                // Current token is Text
-                // Perhaps mixed with variables...
-                for (auto const& subToken : Utility::StringHandler::splitOnSameDepthOf(token, Utility::StringHandler::Delimiter::brace)) {
-                    // Token is type variable
-                    if (isTypeVariable(subToken)) {
-                        parseTokenTypeVariable(subToken);
-                    }
-                    // Token is type text
-                    else {
-                        parseTokenTypeText(subToken);
-                    }
+        if (token.starts_with('$')) {
+            parseTokenTypeEval(token, lateRegistrations, variableNameGenerator);
+        } else {
+            // Current token is Text
+            // Perhaps mixed with variables...
+            for (auto const& subToken : Utility::StringHandler::splitOnSameDepthOf(token, Utility::StringHandler::Delimiter::brace)) {
+                // Token is type variable
+                if (isTypeVariable(subToken)) {
+                    parseTokenTypeVariable(subToken);
+                }
+                // Token is type text
+                else {
+                    parseTokenTypeText(subToken);
                 }
             }
         }

--- a/src/Interaction/Logic/Expression.cpp
+++ b/src/Interaction/Logic/Expression.cpp
@@ -495,7 +495,7 @@ void Expression::parse(std::string_view const expr) {
     evaluationInfo.alwaysTrue = recalculateIsAlwaysTrue();
 }
 
-void Expression::compileIfExpression(std::shared_ptr<ExpressionComponent> const& component) const {
+void Expression::compileIfExpression(std::unique_ptr<ExpressionComponent> const& component) const {
     if (component->type == ExpressionComponent::Type::eval) {
         // Compile the expression using TinyExpr
         int error{};
@@ -546,7 +546,7 @@ void Expression::parseTokenTypeEval(std::string_view const token, std::vector<La
     auto const expression = token.substr(exprStart);
 
     // Write basic component data
-    auto const currentComponent = std::make_shared<ExpressionComponent>();
+    auto currentComponent = std::make_unique<ExpressionComponent>();
     currentComponent->formatter = Formatter::readFormatter(formatter);
     currentComponent->type = ExpressionComponent::Type::eval;
     currentComponent->contextType = ContextDeriver::TargetType::none; // None, since this is an eval expression
@@ -569,11 +569,11 @@ void Expression::parseTokenTypeEval(std::string_view const token, std::vector<La
     }
 
     // Add to components
-    components.push_back(currentComponent);
+    components.push_back(std::move(currentComponent));
 }
 
 void Expression::parseTokenTypeVariable(std::string_view const token) {
-    auto const currentComponent = std::make_shared<ExpressionComponent>();
+    auto currentComponent = std::make_unique<ExpressionComponent>();
 
     // 1.) remove {}
     // We keep all other potential {} inside the variable name for later MultiResolve
@@ -596,20 +596,19 @@ void Expression::parseTokenTypeVariable(std::string_view const token) {
     currentComponent->contextType = ContextDeriver::getTypeFromString(inner);
     currentComponent->key = ContextDeriver::stripContext(inner);
 
-    components.push_back(currentComponent);
+    components.push_back(std::move(currentComponent));
 }
 
 void Expression::parseTokenTypeText(std::string_view const token) {
-    auto const currentComponent = std::make_shared<ExpressionComponent>();
-    // Determine context
+    auto currentComponent = std::make_unique<ExpressionComponent>();
     currentComponent->type = ExpressionComponent::Type::text;
     currentComponent->stringRepresentation = token;
     currentComponent->contextType = ContextDeriver::TargetType::none;
     currentComponent->key = ""; // No key for text expressions
-    components.push_back(currentComponent);
+    components.push_back(std::move(currentComponent));
 }
 
-void Expression::printCompileError(std::shared_ptr<ExpressionComponent> const& component, int const error) const {
+void Expression::printCompileError(std::unique_ptr<ExpressionComponent> const& component, int const error) const {
     std::string offendingChar;
     if (error <= 0 || static_cast<size_t>(error) > component->stringRepresentation.size()) {
         offendingChar = "N/A (error position out of bounds)";

--- a/src/Interaction/Rules/Construction/RulesetCompiler.cpp
+++ b/src/Interaction/Rules/Construction/RulesetCompiler.cpp
@@ -2,7 +2,6 @@
 // Includes
 
 // Standard library
-#include <cstddef>
 #include <memory>
 #include <optional>
 #include <ranges>
@@ -10,6 +9,7 @@
 #include <string_view>
 #include <utility>
 #include <variant>
+#include <vector>
 
 // Nebulite
 #include "Nebulite/Constants/KeyNames.hpp"
@@ -31,56 +31,23 @@
 namespace Nebulite::Interaction::Rules::Construction {
 
 void RulesetCompiler::getFunctionCalls(Data::JsonScope const& entryDoc, JsonRuleset& Ruleset) {
-    // Get function calls: GLOBAL, SELF, OTHER
-    if (entryDoc.memberType(Constants::KeyNames::Ruleset::parseOnGlobal) == Data::KeyType::array) {
-        std::size_t const funcSize = entryDoc.memberSize(Constants::KeyNames::Ruleset::parseOnGlobal);
-        for (std::size_t j = 0; j < funcSize; ++j) {
-            auto const funcKey = Constants::KeyNames::Ruleset::parseOnGlobal.addIndex(j);
-            auto funcCall = entryDoc.get<std::string>(funcKey).value_or("");
-
-            // Create a new Expression, parse the function call
-            Logic::Expression invokeExpr(funcCall);
-            Ruleset.functioncalls_global.emplace_back(std::move(invokeExpr));
+    auto getCalls = [&entryDoc](Data::ScopedKeyView const& key, std::vector<Logic::Expression>& target) {
+        if (entryDoc.memberType(key) == Data::KeyType::array) {
+            for (auto const& indexKey : entryDoc.arrayKeys(key)) {
+                target.emplace_back(entryDoc.get<std::string>(indexKey).value_or(""));
+            }
         }
-    }
-    if (entryDoc.memberType(Constants::KeyNames::Ruleset::parseOnSelf) == Data::KeyType::array) {
-        std::size_t const funcSize = entryDoc.memberSize(Constants::KeyNames::Ruleset::parseOnSelf);
-        for (std::size_t j = 0; j < funcSize; ++j) {
-            auto const funcKey = Constants::KeyNames::Ruleset::parseOnSelf.addIndex(j);
-            auto const funcCall = entryDoc.get<std::string>(funcKey).value_or("");
-
-            // Create a new Expression, parse the function call
-            Logic::Expression invokeExpr(funcCall);
-            Ruleset.functioncalls_self.emplace_back(std::move(invokeExpr));
-        }
-    }
-    if (entryDoc.memberType(Constants::KeyNames::Ruleset::parseOnOther) == Data::KeyType::array) {
-        std::size_t const funcSize = entryDoc.memberSize(Constants::KeyNames::Ruleset::parseOnOther);
-        for (std::size_t j = 0; j < funcSize; ++j) {
-            auto const funcKey = Constants::KeyNames::Ruleset::parseOnOther.addIndex(j);
-            auto const funcCall = entryDoc.get<std::string>(funcKey).value_or("");
-
-            // Create a new Expression, parse the function call
-            Logic::Expression invokeExpr(funcCall);
-            Ruleset.functioncalls_other.emplace_back(std::move(invokeExpr));
-        }
-    }
-}
-
-std::optional<Logic::Assignment> RulesetCompiler::getAssignment(Data::JsonScope const& entry, std::size_t const index) {
-    auto const exprKey = Constants::KeyNames::Ruleset::assignments.addIndex(index);
-    if (Logic::Assignment assignment; assignment.parse(entry.get<std::string>(exprKey).value_or(""))) {
-        return assignment;
-    }
-    return std::nullopt;
+    };
+    getCalls(Constants::KeyNames::Ruleset::parseOnGlobal, Ruleset.functioncalls_global);
+    getCalls(Constants::KeyNames::Ruleset::parseOnSelf, Ruleset.functioncalls_self);
+    getCalls(Constants::KeyNames::Ruleset::parseOnOther, Ruleset.functioncalls_other);
 }
 
 bool RulesetCompiler::getAssignments(std::shared_ptr<JsonRuleset> const& Ruleset, Data::JsonScope const& entry) {
     if (entry.memberType(Constants::KeyNames::Ruleset::assignments) == Data::KeyType::array) {
-        std::size_t const exprSize = entry.memberSize(Constants::KeyNames::Ruleset::assignments);
-        for (std::size_t j = 0; j < exprSize; ++j) {
-            if (auto v = getAssignment(entry, j); v.has_value()) {
-                Ruleset->assignments.emplace_back(std::move(*v));
+        for (auto const& key : entry.arrayKeys(Constants::KeyNames::Ruleset::assignments)) {
+            if (Logic::Assignment assignment; assignment.parse(entry.get<std::string>(key).value_or(""))) {
+                Ruleset->assignments.emplace_back(std::move(assignment));
             }
         }
     } else {
@@ -93,24 +60,23 @@ bool RulesetCompiler::getAssignments(std::shared_ptr<JsonRuleset> const& Ruleset
 std::string RulesetCompiler::getCondition(Data::JsonScope const& entry) {
     std::string logicalArg;
     if (entry.memberType(Constants::KeyNames::Ruleset::condition) == Data::KeyType::array) {
-        std::size_t const logicalArgSize = entry.memberSize(Constants::KeyNames::Ruleset::condition);
-        for (std::size_t j = 0; j < logicalArgSize; ++j) {
-            auto logicalArgKey = Constants::KeyNames::Ruleset::condition.addIndex(j);
-            logicalArg += "(" + entry.get<std::string>(logicalArgKey).value_or("0") + ")";
-            if (j < logicalArgSize - 1) {
-                logicalArg += "*"; // Arguments in vector need to be all true: &-logic -> Multiplication
-            }
+        logicalArg = "$(";
+        for (auto const& key : entry.arrayKeys(Constants::KeyNames::Ruleset::condition)) {
+            logicalArg += "(" + entry.get<std::string>(key).value_or("0") + ")";
+            logicalArg += "*"; // Arguments in vector need to be all true: &-logic -> Multiplication
         }
+        if (logicalArg.ends_with("*")) {
+            logicalArg.pop_back(); // Remove last *
+        }
+        logicalArg += ")";
     } else {
         // Assume simple value, string:
         logicalArg = entry.get<std::string>(Constants::KeyNames::Ruleset::condition).value_or("0");
+        // Ensure logicalArg is encapsulated in an evaluation
+        if (!logicalArg.starts_with("$(")) {
+            logicalArg = "$(" + logicalArg + ")";
+        }
     }
-
-    // Ensure logicalArg is encapsulated in an evaluation
-    if (!logicalArg.starts_with("$(")) {
-        logicalArg = "$(" + logicalArg + ")";
-    }
-
     return logicalArg;
 }
 
@@ -149,17 +115,8 @@ void RulesetCompiler::parse(RulesetVector& rulesetsGlobal, RulesetVector& rulese
         return;
     }
 
-    // Get size of entries
-    std::size_t const size = rulesetArray.memberSize(rulesetArray.getRootScope());
-    if (size == 0) {
-        // Object has no rulesets
-        return;
-    }
-
     // Iterate through all entries
-    for (std::size_t idx = 0; idx < size; ++idx) {
-        // Parse entry into separate JSON object
-        auto const key = rulesetArray.getRootScope().addIndex(idx);
+    for (auto const& key : rulesetArray.arrayKeys(rulesetArray.getRootScope())) {
         auto Ruleset = getRuleset(rulesetArray, key.view(), self);
 
         if (std::holds_alternative<std::monostate>(Ruleset)) {

--- a/src/Interaction/Rules/Construction/RulesetCompiler.cpp
+++ b/src/Interaction/Rules/Construction/RulesetCompiler.cpp
@@ -17,6 +17,7 @@
 #include "Nebulite/Data/Document/JsonScope.hpp"
 #include "Nebulite/Data/Document/KeyType.hpp"
 #include "Nebulite/Interaction/Context.hpp"
+#include "Nebulite/Interaction/Execution/Domain.hpp"
 #include "Nebulite/Interaction/Logic/Assignment.hpp"
 #include "Nebulite/Interaction/Logic/Expression.hpp"
 #include "Nebulite/Interaction/Rules/Construction/RulesetCompiler.hpp"
@@ -170,7 +171,7 @@ void RulesetCompiler::parse(RulesetVector& rulesetsGlobal, RulesetVector& rulese
             // Static ruleset, push directly
             auto staticRulesetPtr = std::get<std::shared_ptr<StaticRuleset>>(Ruleset);
             staticRulesetPtr->estimatedCost = 1; // Static rulesets have minimal cost
-            if (staticRulesetPtr->_isGlobal) {
+            if (staticRulesetPtr->isGlobal()) {
                 rulesetsGlobal.push_back(staticRulesetPtr);
             } else {
                 rulesetsLocal.push_back(staticRulesetPtr);
@@ -183,7 +184,7 @@ void RulesetCompiler::parse(RulesetVector& rulesetsGlobal, RulesetVector& rulese
             auto jsonRulesetPtr = std::get<std::shared_ptr<JsonRuleset>>(Ruleset);
             optimize(jsonRulesetPtr, self.domainScope);
             jsonRulesetPtr->estimateComputationalCost();
-            if (jsonRulesetPtr->_isGlobal) {
+            if (jsonRulesetPtr->isGlobal()) {
                 // If topic is empty, it is a local invoke
                 rulesetsGlobal.push_back(jsonRulesetPtr);
             } else {
@@ -216,8 +217,11 @@ RulesetCompiler::AnyRuleset RulesetCompiler::getRuleset(Data::JsonScope const& d
         ) {
             // Is a valid static ruleset
             auto Ruleset = std::make_shared<StaticRuleset>(self);
-            Ruleset->topic = staticRulesetEntry.topic;
-            Ruleset->_isGlobal = staticRulesetEntry.type == StaticRuleset::Type::Global;
+            if (staticRulesetEntry.type == StaticRuleset::Type::Global) {
+                Ruleset->topic = staticRulesetEntry.topic;
+            } else {
+                Ruleset->topic = ""; // Local rulesets have no topic
+            }
             Ruleset->staticFunction = staticRulesetEntry.function;
             Ruleset->baseListFunction = staticRulesetEntry.baseListFunc;
             Ruleset->slf = staticRulesetEntry.baseListFunc(self);
@@ -241,7 +245,6 @@ RulesetCompiler::AnyRuleset RulesetCompiler::getRuleset(Data::JsonScope const& d
     std::string_view top = Ruleset->topic;
     Utility::StringHandler::strip(top);
     Ruleset->topic = top;
-    Ruleset->_isGlobal = !Ruleset->topic.empty(); // If topic is empty, it is a local ruleset
 
     // Get and parse all assignments
     getAssignments(Ruleset, entry);

--- a/src/Interaction/Rules/Construction/RulesetCompiler.cpp
+++ b/src/Interaction/Rules/Construction/RulesetCompiler.cpp
@@ -21,6 +21,7 @@
 #include "Nebulite/Interaction/Logic/Expression.hpp"
 #include "Nebulite/Interaction/Rules/Construction/RulesetCompiler.hpp"
 #include "Nebulite/Interaction/Rules/Ruleset.hpp"
+#include "Nebulite/Interaction/Rules/StaticRulesetMap.hpp"
 #include "Nebulite/Nebulite.hpp"
 #include "Nebulite/Utility/Ranges.hpp"
 #include "Nebulite/Utility/StringHandler.hpp"
@@ -211,13 +212,14 @@ RulesetCompiler::AnyRuleset RulesetCompiler::getRuleset(Data::JsonScope const& d
 
         if (
             auto const& staticRulesetEntry = StaticRulesetMap::getInstance().getStaticRulesetByName(staticFunctionName);
-            staticRulesetEntry.type != StaticRulesetMap::StaticRulesetWithMetadata::Type::invalid
+            staticRulesetEntry.type != Ruleset::Type::invalid
         ) {
             // Is a valid static ruleset
             auto Ruleset = std::make_shared<StaticRuleset>(self);
             Ruleset->topic = staticRulesetEntry.topic;
-            Ruleset->_isGlobal = staticRulesetEntry.type == StaticRulesetMap::StaticRulesetWithMetadata::Type::Global;
+            Ruleset->_isGlobal = staticRulesetEntry.type == Ruleset::Type::Global;
             Ruleset->staticFunction = staticRulesetEntry.function;
+            Ruleset->instance = staticRulesetEntry.instance;
             Ruleset->baseListFunction = staticRulesetEntry.baseListFunc;
             Ruleset->slf = staticRulesetEntry.baseListFunc(self);
             return Ruleset;

--- a/src/Interaction/Rules/Construction/RulesetCompiler.cpp
+++ b/src/Interaction/Rules/Construction/RulesetCompiler.cpp
@@ -212,12 +212,12 @@ RulesetCompiler::AnyRuleset RulesetCompiler::getRuleset(Data::JsonScope const& d
 
         if (
             auto const& staticRulesetEntry = StaticRulesetMap::getInstance().getStaticRulesetByName(staticFunctionName);
-            staticRulesetEntry.type != Ruleset::Type::invalid
+            staticRulesetEntry.type != StaticRuleset::Type::invalid
         ) {
             // Is a valid static ruleset
             auto Ruleset = std::make_shared<StaticRuleset>(self);
             Ruleset->topic = staticRulesetEntry.topic;
-            Ruleset->_isGlobal = staticRulesetEntry.type == Ruleset::Type::Global;
+            Ruleset->_isGlobal = staticRulesetEntry.type == StaticRuleset::Type::Global;
             Ruleset->staticFunction = staticRulesetEntry.function;
             Ruleset->instance = staticRulesetEntry.instance;
             Ruleset->baseListFunction = staticRulesetEntry.baseListFunc;

--- a/src/Interaction/Rules/Construction/RulesetCompiler.cpp
+++ b/src/Interaction/Rules/Construction/RulesetCompiler.cpp
@@ -219,7 +219,6 @@ RulesetCompiler::AnyRuleset RulesetCompiler::getRuleset(Data::JsonScope const& d
             Ruleset->topic = staticRulesetEntry.topic;
             Ruleset->_isGlobal = staticRulesetEntry.type == StaticRuleset::Type::Global;
             Ruleset->staticFunction = staticRulesetEntry.function;
-            Ruleset->instance = staticRulesetEntry.instance;
             Ruleset->baseListFunction = staticRulesetEntry.baseListFunc;
             Ruleset->slf = staticRulesetEntry.baseListFunc(self);
             return Ruleset;

--- a/src/Interaction/Rules/Listener.cpp
+++ b/src/Interaction/Rules/Listener.cpp
@@ -7,13 +7,14 @@
 
 // Nebulite
 #include "Nebulite/Interaction/Rules/Listener.hpp"
+#include "Nebulite/Interaction/Rules/Ruleset.hpp"
 #include "Nebulite/Interaction/Rules/StaticRulesetMap.hpp"
 
 //------------------------------------------
 namespace Nebulite::Interaction::Rules {
 
 Listener::Listener(Execution::Domain& d, std::string_view const t) : domain(d), topic(t) {
-    if (auto const& entry = StaticRulesetMap::getInstance().getStaticRulesetByName(t); entry.type != StaticRulesetMap::StaticRulesetWithMetadata::Type::invalid) {
+    if (auto const& entry = StaticRulesetMap::getInstance().getStaticRulesetByName(t); entry.type != Ruleset::Type::invalid) {
         // Static ruleset, ensure list of required double values
         otr = entry.baseListFunc(domain);
     }

--- a/src/Interaction/Rules/Listener.cpp
+++ b/src/Interaction/Rules/Listener.cpp
@@ -14,7 +14,7 @@
 namespace Nebulite::Interaction::Rules {
 
 Listener::Listener(Execution::Domain& d, std::string_view const t) : domain(d), topic(t) {
-    if (auto const& entry = StaticRulesetMap::getInstance().getStaticRulesetByName(t); entry.type != Ruleset::Type::invalid) {
+    if (auto const& entry = StaticRulesetMap::getInstance().getStaticRulesetByName(t); entry.type != StaticRuleset::Type::invalid) {
         // Static ruleset, ensure list of required double values
         otr = entry.baseListFunc(domain);
     }

--- a/src/Interaction/Rules/Ruleset.cpp
+++ b/src/Interaction/Rules/Ruleset.cpp
@@ -59,17 +59,17 @@ bool StaticRuleset::evaluateConditionLocally(Execution::Domain& /*global*/) {
 void StaticRuleset::applyContext(Context& context, ContextScope& /*contextScope*/){
     auto* slfFromProvidedContext = baseListFunction(context.self);
     auto* otrFromProvidedContext = baseListFunction(context.other);
-    staticFunction(instance, context, slfFromProvidedContext, otrFromProvidedContext);
+    staticFunction(context, slfFromProvidedContext, otrFromProvidedContext);
 }
 
 void StaticRuleset::applyListener(std::shared_ptr<Listener> const& listener, Execution::Domain& global) {
     Context const context{self, listener->domain, global};
-    staticFunction(instance, context, slf, listener->otr);
+    staticFunction(context, slf, listener->otr);
 }
 
 void StaticRuleset::applyDomain(Execution::Domain& global) {
     Context const context{self, self, global};
-    staticFunction(instance, context, slf, slf);
+    staticFunction(context, slf, slf);
 }
 
 //------------------------------------------

--- a/src/Interaction/Rules/Ruleset.cpp
+++ b/src/Interaction/Rules/Ruleset.cpp
@@ -59,17 +59,17 @@ bool StaticRuleset::evaluateConditionLocally(Execution::Domain& /*global*/) {
 void StaticRuleset::applyContext(Context& context, ContextScope& /*contextScope*/){
     auto* slfFromProvidedContext = baseListFunction(context.self);
     auto* otrFromProvidedContext = baseListFunction(context.other);
-    staticFunction(context, slfFromProvidedContext, otrFromProvidedContext);
+    staticFunction(instance, context, slfFromProvidedContext, otrFromProvidedContext);
 }
 
 void StaticRuleset::applyListener(std::shared_ptr<Listener> const& listener, Execution::Domain& global) {
     Context const context{self, listener->domain, global};
-    staticFunction(context, slf, listener->otr);
+    staticFunction(instance, context, slf, listener->otr);
 }
 
 void StaticRuleset::applyDomain(Execution::Domain& global) {
     Context const context{self, self, global};
-    staticFunction(context, slf, slf);
+    staticFunction(instance, context, slf, slf);
 }
 
 //------------------------------------------

--- a/src/Interaction/Rules/Ruleset.cpp
+++ b/src/Interaction/Rules/Ruleset.cpp
@@ -2,10 +2,7 @@
 // Includes
 
 // Standard library
-#include <cmath>
 #include <cstddef>
-#include <cstdlib>
-#include <limits>
 #include <memory>
 #include <string>
 
@@ -81,23 +78,17 @@ void sendTask(Execution::Domain& domain, std::string const& task) {
 }
 } // namespace
 
-
 //------------------------------------------
 // Derived Class Methods: JsonRuleset
 
 bool JsonRuleset::evaluateConditionGlobally(Execution::Domain& other, Execution::Domain& global) {
     // Check if logical arg is as simple as just "1", meaning true
-    if (logicalArg->isAlwaysTrue())
+    if (logicalArg->isAlwaysTrue()) {
         return true;
+    }
 
     ContextScope const contextScope{self.domainScope, other.domainScope, global.domainScope};
-    double const result = logicalArg->evalAsDouble(contextScope);
-    if (std::isnan(result)) {
-        // We consider NaN as false
-        return false;
-    }
-    // Any double-value unequal to 0 is seen as "true"
-    return std::abs(result) > std::numeric_limits<double>::epsilon();
+    return logicalArg->evalAsBool(contextScope);
 }
 
 void JsonRuleset::applyContext(Context& context, ContextScope& contextScope){

--- a/src/Interaction/Rules/StaticRulesetMap.cpp
+++ b/src/Interaction/Rules/StaticRulesetMap.cpp
@@ -35,11 +35,7 @@ StaticRulesetMap::StaticRulesetMap(){
         .type=StaticRuleset::Type::Local,
         .topic=helpName,
         .description=helpDesc,
-        .instance = this,
-        .function=[](void* instance, Context const& context, double** slf, double** otr) {
-            auto* self = static_cast<StaticRulesetMap*>(instance);
-            self->help(context, slf, otr);
-        },
+        .function=[this](const Context& context, double** slf, double** otr) { help(context, slf, otr); },
         .baseListFunc=helpBaseListFunc
     });
 }
@@ -75,7 +71,6 @@ StaticRulesetMap::StaticRulesetWithMetadata& StaticRulesetMap::getStaticRulesetB
             .type=StaticRuleset::Type::invalid,
             .topic="",
             .description="",
-            .instance = nullptr,
             .function=nullptr
         };
         return invalid;

--- a/src/Interaction/Rules/StaticRulesetMap.cpp
+++ b/src/Interaction/Rules/StaticRulesetMap.cpp
@@ -32,7 +32,7 @@ namespace Nebulite::Interaction::Rules {
 StaticRulesetMap::StaticRulesetMap(){
     Construction::rulesetMapInit(this);
     bindStaticRuleset(StaticRulesetWithMetadata{
-        .type=Ruleset::Type::Local,
+        .type=StaticRuleset::Type::Local,
         .topic=helpName,
         .description=helpDesc,
         .instance = this,
@@ -56,7 +56,7 @@ StaticRulesetMap& StaticRulesetMap::getInstance() {
 std::vector<StaticRulesetMap::StaticRulesetMetadata> StaticRulesetMap::getList() {
     std::vector<StaticRulesetMetadata> list;
     for (auto const& rule : getInstance().container | std::views::values) {
-        if (rule.type != Ruleset::Type::invalid) {
+        if (rule.type != StaticRuleset::Type::invalid) {
             list.push_back(StaticRulesetMetadata{
                 .type=rule.type,
                 .topic=std::string(rule.topic),
@@ -72,7 +72,7 @@ StaticRulesetMap::StaticRulesetWithMetadata& StaticRulesetMap::getStaticRulesetB
     if (statusTracker.mapDeleted) {
         // Using a custom static invalid entry, just in case the in-class one becomes invalid!
         static auto invalid = StaticRulesetWithMetadata{
-            .type=Ruleset::Type::invalid,
+            .type=StaticRuleset::Type::invalid,
             .topic="",
             .description="",
             .instance = nullptr,

--- a/src/Interaction/Rules/StaticRulesetMap.cpp
+++ b/src/Interaction/Rules/StaticRulesetMap.cpp
@@ -32,10 +32,14 @@ namespace Nebulite::Interaction::Rules {
 StaticRulesetMap::StaticRulesetMap(){
     Construction::rulesetMapInit(this);
     bindStaticRuleset(StaticRulesetWithMetadata{
-        .type=StaticRulesetWithMetadata::Type::Local,
+        .type=Ruleset::Type::Local,
         .topic=helpName,
         .description=helpDesc,
-        .function=[this](const Context& context, double** slf, double** otr) { help(context, slf, otr); },
+        .instance = this,
+        .function=[](void* instance, Context const& context, double** slf, double** otr) {
+            auto* self = static_cast<StaticRulesetMap*>(instance);
+            self->help(context, slf, otr);
+        },
         .baseListFunc=helpBaseListFunc
     });
 }
@@ -52,7 +56,7 @@ StaticRulesetMap& StaticRulesetMap::getInstance() {
 std::vector<StaticRulesetMap::StaticRulesetMetadata> StaticRulesetMap::getList() {
     std::vector<StaticRulesetMetadata> list;
     for (auto const& rule : getInstance().container | std::views::values) {
-        if (rule.type != StaticRulesetWithMetadata::Type::invalid) {
+        if (rule.type != Ruleset::Type::invalid) {
             list.push_back(StaticRulesetMetadata{
                 .type=rule.type,
                 .topic=std::string(rule.topic),
@@ -68,9 +72,10 @@ StaticRulesetMap::StaticRulesetWithMetadata& StaticRulesetMap::getStaticRulesetB
     if (statusTracker.mapDeleted) {
         // Using a custom static invalid entry, just in case the in-class one becomes invalid!
         static auto invalid = StaticRulesetWithMetadata{
-            .type=StaticRulesetWithMetadata::Type::invalid,
+            .type=Ruleset::Type::invalid,
             .topic="",
             .description="",
+            .instance = nullptr,
             .function=nullptr
         };
         return invalid;

--- a/src/Module/Base/RulesetModule.cpp
+++ b/src/Module/Base/RulesetModule.cpp
@@ -20,7 +20,7 @@ RulesetModule::RulesetModule(std::string_view const moduleName)
 : id{Data::MappedOrderedCacheList::generateUniqueId(moduleName)}
 {}
 
-Interaction::Rules::Ruleset::BaseListFunction RulesetModule::generateBaseListFunction(std::vector<Data::ScopedKeyView> const& baseKeys) const {
+Interaction::Rules::StaticRuleset::BaseListFunction RulesetModule::generateBaseListFunction(std::vector<Data::ScopedKeyView> const& baseKeys) const {
     return [this, baseKeys](const Interaction::Execution::Domain& domain) -> double** {
         try {
             return domain.ensureOrderedCacheList(id, baseKeys);

--- a/src/Module/Base/RulesetModule.cpp
+++ b/src/Module/Base/RulesetModule.cpp
@@ -20,7 +20,7 @@ RulesetModule::RulesetModule(std::string_view const moduleName)
 : id{Data::MappedOrderedCacheList::generateUniqueId(moduleName)}
 {}
 
-Interaction::Rules::BaseListFunction RulesetModule::generateBaseListFunction(std::vector<Data::ScopedKeyView> const& baseKeys) const {
+Interaction::Rules::Ruleset::BaseListFunction RulesetModule::generateBaseListFunction(std::vector<Data::ScopedKeyView> const& baseKeys) const {
     return [this, baseKeys](const Interaction::Execution::Domain& domain) -> double** {
         try {
             return domain.ensureOrderedCacheList(id, baseKeys);

--- a/src/Module/Ruleset/Camera.cpp
+++ b/src/Module/Ruleset/Camera.cpp
@@ -8,6 +8,7 @@
 #include "Nebulite/Constants/KeyNames.hpp"
 #include "Nebulite/Data/Document/JsonScope.hpp"
 #include "Nebulite/Interaction/Context.hpp"
+#include "Nebulite/Interaction/Rules/Ruleset.hpp"
 #include "Nebulite/Module/Base/RulesetModule.hpp"
 #include "Nebulite/Module/Ruleset/Camera.hpp"
 #include "Nebulite/Nebulite.hpp"
@@ -19,11 +20,11 @@ Camera::Camera() : RulesetModule(moduleName) {
     auto const baseListFunc = generateBaseListFunction(baseKeys);
 
     // Bind Camera-related static rulesets here
-    bind<alignCenterName>(RulesetType::Local, &Camera::alignCenter, alignCenterDesc, baseListFunc);
-    bind<alignTopName>(RulesetType::Local, &Camera::alignTop, alignTopDesc, baseListFunc);
-    bind<alignBottomName>(RulesetType::Local, &Camera::alignBottom, alignBottomDesc, baseListFunc);
-    bind<alignLeftName>(RulesetType::Local, &Camera::alignLeft, alignLeftDesc, baseListFunc);
-    bind<alignRightName>(RulesetType::Local, &Camera::alignRight, alignRightDesc, baseListFunc);
+    bind<alignCenterName, Camera, &Camera::alignCenter>(Interaction::Rules::Ruleset::Type::Local, alignCenterDesc, baseListFunc);
+    bind<alignTopName, Camera, &Camera::alignTop>(Interaction::Rules::Ruleset::Type::Local, alignTopDesc, baseListFunc);
+    bind<alignBottomName, Camera, &Camera::alignBottom>(Interaction::Rules::Ruleset::Type::Local, alignBottomDesc, baseListFunc);
+    bind<alignLeftName, Camera, &Camera::alignLeft>(Interaction::Rules::Ruleset::Type::Local, alignLeftDesc, baseListFunc);
+    bind<alignRightName, Camera, &Camera::alignRight>(Interaction::Rules::Ruleset::Type::Local, alignRightDesc, baseListFunc);
 
     // References
     auto const token = getRulesetModuleAccessToken(*this);

--- a/src/Module/Ruleset/Camera.cpp
+++ b/src/Module/Ruleset/Camera.cpp
@@ -20,11 +20,11 @@ Camera::Camera() : RulesetModule(moduleName) {
     auto const baseListFunc = generateBaseListFunction(baseKeys);
 
     // Bind Camera-related static rulesets here
-    bind<alignCenterName, Camera, &Camera::alignCenter>(Interaction::Rules::StaticRuleset::Type::Local, alignCenterDesc, baseListFunc);
-    bind<alignTopName, Camera, &Camera::alignTop>(Interaction::Rules::StaticRuleset::Type::Local, alignTopDesc, baseListFunc);
-    bind<alignBottomName, Camera, &Camera::alignBottom>(Interaction::Rules::StaticRuleset::Type::Local, alignBottomDesc, baseListFunc);
-    bind<alignLeftName, Camera, &Camera::alignLeft>(Interaction::Rules::StaticRuleset::Type::Local, alignLeftDesc, baseListFunc);
-    bind<alignRightName, Camera, &Camera::alignRight>(Interaction::Rules::StaticRuleset::Type::Local, alignRightDesc, baseListFunc);
+    bind<alignCenterName>(&Camera::alignCenter, baseListFunc, Interaction::Rules::StaticRuleset::Type::Local, alignCenterDesc);
+    bind<alignTopName>(&Camera::alignTop, baseListFunc, Interaction::Rules::StaticRuleset::Type::Local, alignTopDesc);
+    bind<alignBottomName>(&Camera::alignBottom, baseListFunc, Interaction::Rules::StaticRuleset::Type::Local, alignBottomDesc);
+    bind<alignLeftName>(&Camera::alignLeft, baseListFunc, Interaction::Rules::StaticRuleset::Type::Local, alignLeftDesc);
+    bind<alignRightName>(&Camera::alignRight, baseListFunc, Interaction::Rules::StaticRuleset::Type::Local, alignRightDesc);
 
     // References
     auto const token = getRulesetModuleAccessToken(*this);

--- a/src/Module/Ruleset/Camera.cpp
+++ b/src/Module/Ruleset/Camera.cpp
@@ -20,11 +20,11 @@ Camera::Camera() : RulesetModule(moduleName) {
     auto const baseListFunc = generateBaseListFunction(baseKeys);
 
     // Bind Camera-related static rulesets here
-    bind<alignCenterName, Camera, &Camera::alignCenter>(Interaction::Rules::Ruleset::Type::Local, alignCenterDesc, baseListFunc);
-    bind<alignTopName, Camera, &Camera::alignTop>(Interaction::Rules::Ruleset::Type::Local, alignTopDesc, baseListFunc);
-    bind<alignBottomName, Camera, &Camera::alignBottom>(Interaction::Rules::Ruleset::Type::Local, alignBottomDesc, baseListFunc);
-    bind<alignLeftName, Camera, &Camera::alignLeft>(Interaction::Rules::Ruleset::Type::Local, alignLeftDesc, baseListFunc);
-    bind<alignRightName, Camera, &Camera::alignRight>(Interaction::Rules::Ruleset::Type::Local, alignRightDesc, baseListFunc);
+    bind<alignCenterName, Camera, &Camera::alignCenter>(Interaction::Rules::StaticRuleset::Type::Local, alignCenterDesc, baseListFunc);
+    bind<alignTopName, Camera, &Camera::alignTop>(Interaction::Rules::StaticRuleset::Type::Local, alignTopDesc, baseListFunc);
+    bind<alignBottomName, Camera, &Camera::alignBottom>(Interaction::Rules::StaticRuleset::Type::Local, alignBottomDesc, baseListFunc);
+    bind<alignLeftName, Camera, &Camera::alignLeft>(Interaction::Rules::StaticRuleset::Type::Local, alignLeftDesc, baseListFunc);
+    bind<alignRightName, Camera, &Camera::alignRight>(Interaction::Rules::StaticRuleset::Type::Local, alignRightDesc, baseListFunc);
 
     // References
     auto const token = getRulesetModuleAccessToken(*this);

--- a/src/Module/Ruleset/Movement.cpp
+++ b/src/Module/Ruleset/Movement.cpp
@@ -19,10 +19,10 @@ Movement::Movement() : RulesetModule(moduleName) {
     auto const baseListFunc = generateBaseListFunction(baseKeys);
 
     // Global rulesets
-    bind<detectClippingName>(RulesetType::Global, &Movement::detectClipping, detectClippingDesc, baseListFunc);
+    bind<detectClippingName, Movement, &Movement::detectClipping>(Interaction::Rules::Ruleset::Type::Global, detectClippingDesc, baseListFunc);
 
     // Local rulesets
-    bind<processClippingName>(RulesetType::Local, &Movement::processClipping, processClippingDesc, baseListFunc);
+    bind<processClippingName, Movement, &Movement::processClipping>(Interaction::Rules::Ruleset::Type::Local, processClippingDesc, baseListFunc);
 }
 
 // NOLINTNEXTLINE

--- a/src/Module/Ruleset/Movement.cpp
+++ b/src/Module/Ruleset/Movement.cpp
@@ -19,10 +19,10 @@ Movement::Movement() : RulesetModule(moduleName) {
     auto const baseListFunc = generateBaseListFunction(baseKeys);
 
     // Global rulesets
-    bind<detectClippingName, Movement, &Movement::detectClipping>(Interaction::Rules::Ruleset::Type::Global, detectClippingDesc, baseListFunc);
+    bind<detectClippingName, Movement, &Movement::detectClipping>(Interaction::Rules::StaticRuleset::Type::Global, detectClippingDesc, baseListFunc);
 
     // Local rulesets
-    bind<processClippingName, Movement, &Movement::processClipping>(Interaction::Rules::Ruleset::Type::Local, processClippingDesc, baseListFunc);
+    bind<processClippingName, Movement, &Movement::processClipping>(Interaction::Rules::StaticRuleset::Type::Local, processClippingDesc, baseListFunc);
 }
 
 // NOLINTNEXTLINE

--- a/src/Module/Ruleset/Movement.cpp
+++ b/src/Module/Ruleset/Movement.cpp
@@ -19,10 +19,10 @@ Movement::Movement() : RulesetModule(moduleName) {
     auto const baseListFunc = generateBaseListFunction(baseKeys);
 
     // Global rulesets
-    bind<detectClippingName, Movement, &Movement::detectClipping>(Interaction::Rules::StaticRuleset::Type::Global, detectClippingDesc, baseListFunc);
+    bind<detectClippingName>(&Movement::detectClipping, baseListFunc, Interaction::Rules::StaticRuleset::Type::Global, detectClippingDesc);
 
     // Local rulesets
-    bind<processClippingName, Movement, &Movement::processClipping>(Interaction::Rules::StaticRuleset::Type::Local, processClippingDesc, baseListFunc);
+    bind<processClippingName>(&Movement::processClipping, baseListFunc, Interaction::Rules::StaticRuleset::Type::Local, processClippingDesc);
 }
 
 // NOLINTNEXTLINE

--- a/src/Module/Ruleset/Physics.cpp
+++ b/src/Module/Ruleset/Physics.cpp
@@ -25,14 +25,14 @@ Physics::Physics() : RulesetModule(moduleName) {
     auto const baseListFunc = generateBaseListFunction(baseKeys);
 
     // Global rulesets
-    bind<elasticCollisionName, Physics, &Physics::elasticCollision>(Interaction::Rules::Ruleset::Type::Global, elasticCollisionDesc, baseListFunc);
-    bind<gravityName, Physics, &Physics::gravity>(Interaction::Rules::Ruleset::Type::Global, gravityDesc, baseListFunc);
+    bind<elasticCollisionName, Physics, &Physics::elasticCollision>(Interaction::Rules::StaticRuleset::Type::Global, elasticCollisionDesc, baseListFunc);
+    bind<gravityName, Physics, &Physics::gravity>(Interaction::Rules::StaticRuleset::Type::Global, gravityDesc, baseListFunc);
 
     // Local rulesets
-    bind<storeLastPositionName, Physics, &Physics::storeLastPosition>(Interaction::Rules::Ruleset::Type::Local, storeLastPositionDesc, baseListFunc);
-    bind<applyForceName, Physics, &Physics::applyForce>(Interaction::Rules::Ruleset::Type::Local, applyForceDesc, baseListFunc);
-    bind<applyCorrectionName, Physics, &Physics::applyCorrection>(Interaction::Rules::Ruleset::Type::Local, applyCorrectionDesc, baseListFunc);
-    bind<dragName, Physics, &Physics::drag>(Interaction::Rules::Ruleset::Type::Local, dragDesc, baseListFunc);
+    bind<storeLastPositionName, Physics, &Physics::storeLastPosition>(Interaction::Rules::StaticRuleset::Type::Local, storeLastPositionDesc, baseListFunc);
+    bind<applyForceName, Physics, &Physics::applyForce>(Interaction::Rules::StaticRuleset::Type::Local, applyForceDesc, baseListFunc);
+    bind<applyCorrectionName, Physics, &Physics::applyCorrection>(Interaction::Rules::StaticRuleset::Type::Local, applyCorrectionDesc, baseListFunc);
+    bind<dragName, Physics, &Physics::drag>(Interaction::Rules::StaticRuleset::Type::Local, dragDesc, baseListFunc);
 
     // Global Variables
     auto const token = getRulesetModuleAccessToken(*this);

--- a/src/Module/Ruleset/Physics.cpp
+++ b/src/Module/Ruleset/Physics.cpp
@@ -25,14 +25,14 @@ Physics::Physics() : RulesetModule(moduleName) {
     auto const baseListFunc = generateBaseListFunction(baseKeys);
 
     // Global rulesets
-    bind<elasticCollisionName, Physics, &Physics::elasticCollision>(Interaction::Rules::StaticRuleset::Type::Global, elasticCollisionDesc, baseListFunc);
-    bind<gravityName, Physics, &Physics::gravity>(Interaction::Rules::StaticRuleset::Type::Global, gravityDesc, baseListFunc);
+    bind<elasticCollisionName>(&Physics::elasticCollision, baseListFunc, Interaction::Rules::StaticRuleset::Type::Global, elasticCollisionDesc);
+    bind<gravityName>(&Physics::gravity, baseListFunc, Interaction::Rules::StaticRuleset::Type::Global, gravityDesc);
 
     // Local rulesets
-    bind<storeLastPositionName, Physics, &Physics::storeLastPosition>(Interaction::Rules::StaticRuleset::Type::Local, storeLastPositionDesc, baseListFunc);
-    bind<applyForceName, Physics, &Physics::applyForce>(Interaction::Rules::StaticRuleset::Type::Local, applyForceDesc, baseListFunc);
-    bind<applyCorrectionName, Physics, &Physics::applyCorrection>(Interaction::Rules::StaticRuleset::Type::Local, applyCorrectionDesc, baseListFunc);
-    bind<dragName, Physics, &Physics::drag>(Interaction::Rules::StaticRuleset::Type::Local, dragDesc, baseListFunc);
+    bind<storeLastPositionName>(&Physics::storeLastPosition, baseListFunc, Interaction::Rules::StaticRuleset::Type::Local, storeLastPositionDesc);
+    bind<applyForceName>(&Physics::applyForce, baseListFunc, Interaction::Rules::StaticRuleset::Type::Local, applyForceDesc);
+    bind<applyCorrectionName>(&Physics::applyCorrection, baseListFunc, Interaction::Rules::StaticRuleset::Type::Local, applyCorrectionDesc);
+    bind<dragName>(&Physics::drag, baseListFunc, Interaction::Rules::StaticRuleset::Type::Local, dragDesc);
 
     // Global Variables
     auto const token = getRulesetModuleAccessToken(*this);

--- a/src/Module/Ruleset/Physics.cpp
+++ b/src/Module/Ruleset/Physics.cpp
@@ -9,6 +9,7 @@
 // Nebulite
 #include "Nebulite/Core/GlobalSpace.hpp"
 #include "Nebulite/Interaction/Context.hpp"
+#include "Nebulite/Interaction/Rules/Ruleset.hpp"
 #include "Nebulite/Interaction/Rules/StaticRulesetMap.hpp"
 #include "Nebulite/Math/Equality.hpp"
 #include "Nebulite/Module/Domain/GlobalSpace/Physics.hpp"
@@ -24,14 +25,14 @@ Physics::Physics() : RulesetModule(moduleName) {
     auto const baseListFunc = generateBaseListFunction(baseKeys);
 
     // Global rulesets
-    bind<elasticCollisionName>(RulesetType::Global, &Physics::elasticCollision, elasticCollisionDesc, baseListFunc);
-    bind<gravityName>(RulesetType::Global, &Physics::gravity, gravityDesc, baseListFunc);
+    bind<elasticCollisionName, Physics, &Physics::elasticCollision>(Interaction::Rules::Ruleset::Type::Global, elasticCollisionDesc, baseListFunc);
+    bind<gravityName, Physics, &Physics::gravity>(Interaction::Rules::Ruleset::Type::Global, gravityDesc, baseListFunc);
 
     // Local rulesets
-    bind<storeLastPositionName>(RulesetType::Local, &Physics::storeLastPosition, storeLastPositionDesc, baseListFunc);
-    bind<applyForceName>(RulesetType::Local, &Physics::applyForce, applyForceDesc, baseListFunc);
-    bind<applyCorrectionName>(RulesetType::Local, &Physics::applyCorrection, applyCorrectionDesc, baseListFunc);
-    bind<dragName>(RulesetType::Local, &Physics::drag, dragDesc, baseListFunc);
+    bind<storeLastPositionName, Physics, &Physics::storeLastPosition>(Interaction::Rules::Ruleset::Type::Local, storeLastPositionDesc, baseListFunc);
+    bind<applyForceName, Physics, &Physics::applyForce>(Interaction::Rules::Ruleset::Type::Local, applyForceDesc, baseListFunc);
+    bind<applyCorrectionName, Physics, &Physics::applyCorrection>(Interaction::Rules::Ruleset::Type::Local, applyCorrectionDesc, baseListFunc);
+    bind<dragName, Physics, &Physics::drag>(Interaction::Rules::Ruleset::Type::Local, dragDesc, baseListFunc);
 
     // Global Variables
     auto const token = getRulesetModuleAccessToken(*this);


### PR DESCRIPTION
Summary: Reorganizes and simplifies the ruleset subsystem for clarity and maintainability. Major work includes splitting responsibilities, simplifying condition/expression handling, and cleaning unused APIs.
What changed:

- RulesetCompiler (simplified call/extraction logic)
- Expression parsing & ownership (shared_ptr -> unique_ptr)
- Ruleset class cleanup (isGlobal, removed unused methods, moved some members from base class to specialized class), bindings/refactor of function types, various include/import path adjustments.