### PR TITLE
Refactor Expression evaluation methods: implement type-safe returnability checks using Utility::Promise

### DIFF
--- a/include/Nebulite/Interaction/Logic/Expression.hpp
+++ b/include/Nebulite/Interaction/Logic/Expression.hpp
@@ -23,6 +23,7 @@
 #include "Nebulite/Interaction/Context.hpp"
 #include "Nebulite/Interaction/Logic/ExpressionComponent.hpp"
 #include "Nebulite/Interaction/Logic/LinkedNumericValue.hpp"
+#include "Nebulite/Utility/Promise.hpp"
 
 //------------------------------------------
 // Forward declarations
@@ -76,6 +77,118 @@ public:
     static constexpr std::size_t standardRecursionDepth = 8;
 
     //------------------------------------------
+    // Returnable checks
+
+    /**
+     * @brief Checks if the expression can be returned as a string without loss of information.
+     * @return True if the expression can be returned as a string, false otherwise.
+     */
+    bool isReturnableAsString() const noexcept { return evaluationInfo.returnableAsString; }
+
+    /**
+     * @brief Checks if the expression can be returned as a boolean without loss of information.
+     * @return True if the expression can be returned as a boolean, false otherwise.
+     */
+    bool isReturnableAsBool() const noexcept { return evaluationInfo.simpleExpression; }
+
+    /**
+     * @brief Checks if the expression can be returned as an integer without loss of information.
+     * @details Not true if the expression is a simple expression with padding, e.g. $05i(...) would be a string, not an int.
+     *          Only true for simple expressions with an int cast: $i(...)
+     * @return True if the expression can be returned as an integer, false otherwise.
+     */
+    bool isReturnableAsInt() const noexcept { return evaluationInfo.simpleExpressionWithIntCast; }
+
+    /**
+     * @brief Checks if the expression can be returned as a double without loss of information.
+     * @details Only true for simple expressions without any formatting, e.g. $(...) would be a double, but $03.2f(...) would be a string.
+     * @return True if the expression can be returned as a double, false otherwise.
+     */
+    bool isReturnableAsDouble() const noexcept { return evaluationInfo.simpleExpression; }
+
+    /**
+     * @brief Checks if the expression is always true, meaning it evaluates to a non-zero numeric value.
+     * @details This is only true for simple expressions that evaluate to a non-zero numeric value, e.g. $(1) or $i(1).
+     *          It is false for expressions that evaluate to zero, non-numeric values or expressions with padding/formatting
+     *          that isn't just an integer cast.
+     * @return True if the expression is always true, false otherwise.
+     */
+    bool isAlwaysTrue() const noexcept { return evaluationInfo.alwaysTrue; }
+
+    //------------------------------------------
+    // Actual evaluation functions
+
+    /**
+     * @brief Evaluates the expression and returns the result as a string.
+     * @details Complex variables are allowed, but will be shortened to '[array]' or '{object}' if they are not convertible to a string.
+     * @param context The context to evaluate the expression against.
+     * @param recursionDepth The maximum recursion depth for nested evaluations. Defaults to standardRecursionDepth.
+     * @return The result of the evaluation as a string.
+     */
+    [[nodiscard]] std::string eval(ContextScope const& context, std::size_t recursionDepth = standardRecursionDepth) const ;
+
+    /**
+     * @brief Canonical, typesafe evaluation function that returns a JSON document.
+     * @param context The context to evaluate the expression against.
+     * @param recursionDepth The maximum recursion depth for nested evaluations. Defaults to standardRecursionDepth.
+     * @return The result of the evaluation as a JSON document.
+     */
+    [[nodiscard]] Data::JSON evalAsJson(ContextScope const& context, std::size_t recursionDepth = standardRecursionDepth) const ;
+
+    /**
+     * @brief Evaluates the expression and returns the result as a double.
+     * @param context The context to evaluate the expression against.
+     * @param promise A promise that the expression is returnable as a double. This is used to ensure type safety. This reduces conditional checks in hot loops.
+     *                The promise itself does not affect the evaluation, it is for the user as a reminder that the expression must be returnable as a double.
+     *                If that promise is not fulfilled, the evaluation can result in undefined behavior.
+     * @return The result of the evaluation as a double.
+     */
+    [[nodiscard]] double evalAsDouble(ContextScope const& context, Utility::Promise<&Expression::isReturnableAsDouble> promise) const ;
+
+    /**
+     * @brief Evaluates the expression and returns the result as an integer.
+     * @param context The context to evaluate the expression against.
+     * @param promise A promise that the expression is returnable as an integer. This is used to ensure type safety. This reduces conditional checks in hot loops.
+     *                The promise itself does not affect the evaluation, it is for the user as a reminder that the expression must be returnable as an integer.
+     *                If that promise is not fulfilled, the evaluation can result in undefined behavior.
+     * @return The result of the evaluation as an integer.
+     */
+    [[nodiscard]] std::int64_t evalAsInt(ContextScope const& context, Utility::Promise<&Expression::isReturnableAsInt> promise) const ;
+
+    /**
+     * @brief Evaluates the expression and returns the result as a boolean.
+     * @param context The context to evaluate the expression against.
+     * @param promise A promise that the expression is returnable as a boolean. This is used to ensure type safety. This reduces conditional checks in hot loops.
+     *                The promise itself does not affect the evaluation, it is for the user as a reminder that the expression must be returnable as a boolean.
+     *                If that promise is not fulfilled, the evaluation can result in undefined behavior.
+     * @return The result of the evaluation as a boolean.
+     */
+    [[nodiscard]] bool evalAsBool(ContextScope const& context, Utility::Promise<&Expression::isReturnableAsBool> promise) const ;
+
+    //------------------------------------------
+    // Static functions for one-time evaluation
+
+    static std::string eval(std::string_view input, ContextScope const& context);
+
+    static Data::JSON evalAsJson(std::string_view input, ContextScope const& context);
+
+    //------------------------------------------
+    // Getter
+
+    /**
+     * @brief Gets the full expression string that was parsed.
+     * @return The full expression string.
+     */
+    [[nodiscard]] std::string const& getFullExpression() const noexcept ;
+
+private:
+    /**
+     * @brief The maximum recursion depth without temporary string allocation
+     * @details Used for Utility::Coordination::RecursionAllocator
+     */
+    static auto constexpr allocatedRecursionDepth = 8;
+
+    //------------------------------------------
     // Evaluation info
 
     /**
@@ -111,55 +224,6 @@ public:
          */
         bool alwaysTrue = false;
     };
-
-    //------------------------------------------
-    // Actual evaluation functions
-
-    [[nodiscard]] std::string eval(ContextScope const& context, std::size_t recursionDepth = standardRecursionDepth) const ;
-
-    // Typesafe eval
-    [[nodiscard]] Data::JSON evalAsJson(ContextScope const& context, std::size_t recursionDepth = standardRecursionDepth) const ;
-
-    // Unsafe evaluations:
-
-    // Requires check for returnability before calling!
-    [[nodiscard]] double evalAsDouble(ContextScope const& context) const ;
-
-    // Requires check for returnability before calling!
-    [[nodiscard]] std::int64_t evalAsInt(ContextScope const& context) const ;
-
-    // Requires check for returnability before calling!
-    [[nodiscard]] bool evalAsBool(ContextScope const& context) const ;
-
-    //------------------------------------------
-    // Static functions for one-time evaluation
-
-    static std::string eval(std::string_view input, ContextScope const& context);
-
-    static Data::JSON evalAsJson(std::string_view input, ContextScope const& context);
-
-    //------------------------------------------
-    // Getter
-
-    /**
-     * @brief Gets the full expression string that was parsed.
-     * @return The full expression string.
-     */
-    [[nodiscard]] std::string const& getFullExpression() const noexcept ;
-
-    EvaluationInfo const& getEvaluationInfo() const noexcept {
-        return evaluationInfo;
-    }
-
-private:
-    /**
-     * @brief The maximum recursion depth without temporary string allocation
-     * @details Used for Utility::Coordination::RecursionAllocator
-     */
-    static auto constexpr allocatedRecursionDepth = 8;
-
-    //------------------------------------------
-    // Evaluation info
 
     void recalculateEvaluationInfo() noexcept ;
 

--- a/include/Nebulite/Interaction/Rules/Ruleset.hpp
+++ b/include/Nebulite/Interaction/Rules/Ruleset.hpp
@@ -155,7 +155,7 @@ protected:
      * @brief The topic of the ruleset, used for routing and filtering in the broadcast-listen-model of the Invoke class.
      * @details Not the same as the name of the ruleset, which is not stored.
      *          If the ruleset is local, the topic is empty.
-     * @todo Use topicId instead? + modulo-based rulesetmap?
+     * @todo Use topicId instead? + modulo-based rulesetMap?
      */
     std::string topic = "all";
 };

--- a/include/Nebulite/Utility/Promise.hpp
+++ b/include/Nebulite/Utility/Promise.hpp
@@ -1,0 +1,41 @@
+#ifndef NEBULITE_UTILITY_PROMISE_HPP
+#define NEBULITE_UTILITY_PROMISE_HPP
+
+//------------------------------------------
+// Includes
+
+// Standard library
+#include <type_traits>
+
+//------------------------------------------
+namespace Nebulite::Utility {
+template <auto Check>
+struct Promise {
+    // The Check template parameter must either be of type bool or a callable that returns a bool
+    static_assert(
+        std::is_member_function_pointer_v<decltype(Check)> ||
+        std::is_member_object_pointer_v<decltype(Check)>,
+        "Check must be a pointer to a member function or a member object."
+    );
+};
+
+struct Any {};
+struct All {};
+
+template <typename Policy, auto... Checks>
+struct PromiseList {
+    static_assert(
+        std::is_same_v<Policy, Any> || std::is_same_v<Policy, All>,
+        "Policy must be either Any or All."
+    );
+    static_assert(
+        (... && (
+            std::is_member_function_pointer_v<decltype(Checks)> ||
+            std::is_member_object_pointer_v<decltype(Checks)>
+        )),
+        "Each check must be a pointer to a member function or member object."
+    );
+};
+
+} // namespace Nebulite::Utility
+#endif // NEBULITE_UTILITY_PROMISE_HPP

--- a/src/Interaction/Logic/Assignment.cpp
+++ b/src/Interaction/Logic/Assignment.cpp
@@ -20,6 +20,7 @@
 #include "Nebulite/Interaction/Logic/Assignment.hpp"
 #include "Nebulite/Interaction/Logic/Expression.hpp"
 #include "Nebulite/Nebulite.hpp"
+#include "Nebulite/Utility/Promise.hpp"
 #include "Nebulite/Utility/StringHandler.hpp"
 
 //------------------------------------------
@@ -223,8 +224,8 @@ void Assignment::apply(ContextScope const& context) const {
     // Update
 
     // If the expression is returnable as double, we can optimize numeric operations
-    if (expression->getEvaluationInfo().simpleExpression && isNumericOperation(operation)) {
-        double const resolved = expression->evalAsDouble(context);
+    if (expression->isReturnableAsDouble() && isNumericOperation(operation)) {
+        double const resolved = expression->evalAsDouble(context, Utility::Promise<&Expression::isReturnableAsDouble>{});
         if (targetValuePtr != nullptr) {
             setValueOfKey(resolved, targetValuePtr);
         } else {
@@ -248,13 +249,13 @@ void Assignment::apply(ContextScope const& context) const {
     // If the expression is returnable as int, we use that
     // only $i(...) is supported, as any formatting like $05i(...)
     // would make the result a string to respect formatting
-    else if (expression->getEvaluationInfo().simpleExpressionWithIntCast && isNumericOperation(operation)) {
-        auto const resolved = expression->evalAsInt(context);
+    else if (expression->isReturnableAsInt() && isNumericOperation(operation)) {
+        auto const resolved = expression->evalAsInt(context, Utility::Promise<&Expression::isReturnableAsInt>{});
         auto const scopedKey = Data::ScopedKey(key->eval(context));
         setValueOfKey(scopedKey.view(), resolved, targetDocument);
     }
     // Check if returning as a JSON is preferred
-    else if (!expression->getEvaluationInfo().returnableAsString && this->operation == Operation::set) {
+    else if (!expression->isReturnableAsString() && this->operation == Operation::set) {
         auto const resolved = expression->evalAsJson(context);
         auto const k = Data::ScopedKey(key->eval(context));
         targetDocument.setSubDoc(k.view(), std::move(resolved));

--- a/src/Interaction/Logic/Expression.cpp
+++ b/src/Interaction/Logic/Expression.cpp
@@ -8,7 +8,6 @@
 #include <cstddef>
 #include <cstdint> // NOLINT
 #include <iterator>
-#include <limits>
 #include <memory>
 #include <ranges>
 #include <sstream>
@@ -34,6 +33,7 @@
 #include "Nebulite/Nebulite.hpp"
 #include "Nebulite/Utility/CompileTimeEvaluate.hpp"
 #include "Nebulite/Utility/Coordination/RecursionAllocator.hpp"
+#include "Nebulite/Utility/Promise.hpp"
 #include "Nebulite/Utility/Ranges.hpp"
 #include "Nebulite/Utility/StringHandler.hpp"
 
@@ -219,24 +219,19 @@ Data::JSON Expression::evalAsJson(ContextScope const& context, std::size_t const
     return jsonResult;
 }
 
-double Expression::evalAsDouble(ContextScope const& context) const {
-    if (!evaluationInfo.simpleExpression) {
-        Global::capture().error.println(__FUNCTION__, ": Expression is not returnable as double! Returning NaN.");
-        return std::numeric_limits<double>::quiet_NaN();
-    }
+double Expression::evalAsDouble(ContextScope const& context, Utility::Promise<&Expression::isReturnableAsDouble> /*promise*/) const {
+    assert(isReturnableAsDouble() && "Expression is not returnable as double! Promise not fulfilled.");
     return components[0].evalAsDouble([&]{updateCaches(context);});
 }
 
-int64_t Expression::evalAsInt(ContextScope const& context) const {
-    if (!evaluationInfo.simpleExpressionWithIntCast) {
-        Global::capture().error.println(__FUNCTION__, ": Expression is not returnable as int! Returning 0.");
-        return 0;
-    }
+int64_t Expression::evalAsInt(ContextScope const& context, Utility::Promise<&Expression::isReturnableAsInt> /*promise*/) const {
+    assert(isReturnableAsInt() && "Expression is not returnable as int! Promise not fulfilled.");
     return static_cast<int64_t>(components[0].evalAsDouble([&]{updateCaches(context);}));
 }
 
-bool Expression::evalAsBool(ContextScope const& context) const {
-    double const result = evalAsDouble(context);
+bool Expression::evalAsBool(ContextScope const& context, Utility::Promise<&Expression::isReturnableAsBool> /*promise*/) const {
+    assert(isReturnableAsBool() && "Expression is not returnable as bool! Promise not fulfilled.");
+    double const result = evalAsDouble(context, Utility::Promise<&Expression::isReturnableAsDouble>{});
     if (std::isnan(result)) {
         // We consider NaN as false
         return false;

--- a/src/Interaction/Rules/Construction/RulesetCompiler.cpp
+++ b/src/Interaction/Rules/Construction/RulesetCompiler.cpp
@@ -197,6 +197,10 @@ RulesetCompiler::AnyRuleset RulesetCompiler::getRuleset(Data::JsonScope const& d
     std::string_view lsa = logicalArgStr;
     Utility::StringHandler::strip(lsa);
     Ruleset->logicalArg = std::make_unique<Logic::Expression>(lsa);
+    if (!Ruleset->logicalArg->isReturnableAsBool()) {
+        Global::capture().error.println("Ruleset entry with logical arg '", lsa, "' cannot be evaluated as a boolean. Skipping entry.");
+        return std::monostate{};
+    }
 
     // Remove whitespaces at start and end from topic:
     std::string_view top = Ruleset->topic;

--- a/src/Interaction/Rules/Ruleset.cpp
+++ b/src/Interaction/Rules/Ruleset.cpp
@@ -11,6 +11,7 @@
 #include "Nebulite/Interaction/Execution/Domain.hpp"
 #include "Nebulite/Interaction/Rules/Listener.hpp"
 #include "Nebulite/Interaction/Rules/Ruleset.hpp"
+#include "Nebulite/Utility/Promise.hpp"
 
 //------------------------------------------
 namespace Nebulite::Interaction::Rules {
@@ -83,12 +84,13 @@ void sendTask(Execution::Domain& domain, std::string const& task) {
 
 bool JsonRuleset::evaluateConditionGlobally(Execution::Domain& other, Execution::Domain& global) {
     // Check if logical arg is as simple as just "1", meaning true
-    if (logicalArg->getEvaluationInfo().alwaysTrue) {
+    if (logicalArg->isAlwaysTrue()) {
         return true;
     }
 
+    // Promise was fulfilled during ruleset parsing
     ContextScope const contextScope{self.domainScope, other.domainScope, global.domainScope};
-    return logicalArg->evalAsBool(contextScope);
+    return logicalArg->evalAsBool(contextScope, Utility::Promise<&Logic::Expression::isReturnableAsBool>{});
 }
 
 void JsonRuleset::applyContext(Context& context, ContextScope& contextScope){

--- a/src/Module/Domain/Common/General.cpp
+++ b/src/Module/Domain/Common/General.cpp
@@ -21,6 +21,7 @@
 #include "Nebulite/Interaction/Logic/Expression.hpp"
 #include "Nebulite/Module/Domain/Common/General.hpp"
 #include "Nebulite/Nebulite.hpp"
+#include "Nebulite/Utility/Promise.hpp"
 #include "Nebulite/Utility/Ranges.hpp"
 #include "Nebulite/Utility/StringHandler.hpp"
 
@@ -136,11 +137,11 @@ Constants::Event General::func_if(std::span<std::string_view const> const& args,
     // Conditional check
     // We ensured that the condition is wrapped in $() above, but there could still be parsing errors (missing parenthesis etc.)
     Interaction::Logic::Expression const expr(condition);
-    if (!expr.getEvaluationInfo().simpleExpression) {
+    if (!expr.isReturnableAsBool()) {
         ctx.self.capture.error.println("Critical Error: A custom if-condition failed.\nCondition failed: " + condition + " is not a boolean expression.");
         return Constants::Event::Warning;
     }
-    if (expr.evalAsBool(ctxScope)) {
+    if (expr.evalAsBool(ctxScope, Utility::Promise<&Interaction::Logic::Expression::isReturnableAsBool>{})) {
         commands = __FUNCTION__ + std::string(" ") + commands;
         return ctx.self.parseStr(commands, ctx, ctxScope);
     }
@@ -161,11 +162,11 @@ Constants::Event General::func_assert(std::span<std::string_view const> const& a
     // Conditional check
     // We ensured that the condition is wrapped in $() above, but there could still be parsing errors (missing parenthesis etc.)
     Interaction::Logic::Expression const expr(condition);
-    if (!expr.getEvaluationInfo().simpleExpression) {
+    if (!expr.isReturnableAsBool()) {
         ctx.self.capture.error.println("Critical Error: A custom assertion failed.\nAssertion failed: " + condition + " is not a boolean expression.");
         return Constants::Event::Error;
     }
-    if (!expr.evalAsBool(ctxScope)) {
+    if (!expr.evalAsBool(ctxScope, Utility::Promise<&Interaction::Logic::Expression::isReturnableAsBool>{})) {
         ctx.self.capture.error.println("Critical Error: A custom assertion failed.\nAssertion failed: " + condition + " is not true.");
         return Constants::Event::Error;
     }

--- a/src/Module/Transformation/Filter.cpp
+++ b/src/Module/Transformation/Filter.cpp
@@ -19,6 +19,7 @@
 #include "Nebulite/Interaction/Logic/Expression.hpp"
 #include "Nebulite/Module/Transformation/Filter.hpp"
 #include "Nebulite/Utility/Glob.hpp"
+#include "Nebulite/Utility/Promise.hpp"
 #include "Nebulite/Utility/Ranges.hpp"
 #include "Nebulite/Utility/StringHandler.hpp"
 
@@ -183,6 +184,7 @@ bool Filter::filterCustom(std::span<std::string_view const> const& args, Data::J
     if (jsonDoc.memberType(rootKey) != Data::KeyType::array) return false; // Not an array, cannot sort
     if (args.size() < 2) return false;
     Interaction::Logic::Expression const expression('$' + Utility::StringHandler::recombineArgs(args.subspan(1)));
+    if (!expression.isReturnableAsBool()) return false;
     arrayFilter(jsonDoc, [&](Data::JsonScope& element) {
         Interaction::ContextScope const ctxScope{
             {
@@ -191,7 +193,7 @@ bool Filter::filterCustom(std::span<std::string_view const> const& args, Data::J
                 .global = element
             }
         };
-        return expression.evalAsBool(ctxScope);
+        return expression.evalAsBool(ctxScope, Utility::Promise<&Interaction::Logic::Expression::isReturnableAsBool>{});
     });
     return true;
 }

--- a/src/Module/Transformation/Sort.cpp
+++ b/src/Module/Transformation/Sort.cpp
@@ -11,6 +11,7 @@
 #include "Nebulite/Interaction/Context.hpp"
 #include "Nebulite/Interaction/Logic/Expression.hpp"
 #include "Nebulite/Module/Transformation/Sort.hpp"
+#include "Nebulite/Utility/Promise.hpp"
 #include "Nebulite/Utility/Sort.hpp"
 #include "Nebulite/Utility/StringHandler.hpp"
 
@@ -53,6 +54,7 @@ bool Sort::sortCustom(std::span<std::string_view const> const& args, Data::JsonS
     if (jsonDoc.memberType(rootKey) != Data::KeyType::array) return false; // Not an array, cannot sort
     if (args.size() < 2) return false;
     Interaction::Logic::Expression const expression('$' + Utility::StringHandler::recombineArgs(args.subspan(1)));
+    if (!expression.isReturnableAsBool()) return false;
     arraySort<bool>(jsonDoc, false, [&](auto& a, auto& b) {
         auto& slf = a.second.shareManagedScope("");
         auto& otr = b.second.shareManagedScope("");
@@ -63,7 +65,7 @@ bool Sort::sortCustom(std::span<std::string_view const> const& args, Data::JsonS
                 .global = slf
             }
         };
-        return expression.evalAsBool(ctxScope);
+        return expression.evalAsBool(ctxScope, Utility::Promise<&Interaction::Logic::Expression::isReturnableAsBool>{});
     });
     return true;
 }


### PR DESCRIPTION
This should make accidental unsafe evaluations less likely.